### PR TITLE
Change default Go version from "1.17" to "stable"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
   go-version:
     description: "Version of Go to use"
     required: false
-    default: "1.17"
+    default: "stable"
   node-version:
     description: "Node js version"
     required: false


### PR DESCRIPTION
This action fails when installing Wails with the following output:
Error: ../../../go/pkg/mod/github.com/wailsapp/wails/v2@v2.2.0/pkg/templates/templates.go:28:12: pattern all:ides/*: no matching files found
Error: Process completed with exit code 1.
The reason for this failure is because the Go version is less than 1.18, which can be read about here: https://wails.io/docs/gettingstarted/installation/#installing-wails