### PR TITLE
Updated 3rd-party actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,16 +101,15 @@ runs:
   steps:
     # Setup and configure GoLang
     - name: Setup GoLang
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         check-latest: true
-        cache: true
         go-version: ${{inputs.go-version}}
     - run: go version
       shell: bash
     # Setup and configure NodeJS
     - name: Setup NodeJS
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{inputs.node-version}}
     # (Optional) Setup and configure Deno
@@ -234,7 +233,7 @@ runs:
         echo "Signing Installer" & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe' sign /fd sha256 /tr http://ts.ssl.com /f certificate\certificate.pfx /p '${{ inputs.sign-windows-cert-password }}' .\build\bin\${{inputs.build-name}}-amd64-installer.exe
 
     # Upload build assets
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: inputs.package == 'true'
       with:
         name: Wails Build ${{runner.os}} ${{inputs.build-name}}


### PR DESCRIPTION
This PR updates the 3rd-party actions used in wails-build-action, so that the action no longer throws deprecation warnings.

The `cache` property was removed for `setup-go` as it's now always on unless you specifically tell it not to cache.