### PR TITLE
feat: allow to pass tags to wails build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ By default, the action will build and upload the results to github, on a tagged 
 | `sign`                               | `false`              | After build, signs and creates signed installers   |
 | `package`                            | `true`               | Upload workflow artifacts & publish release on tag |
 | `build-platform`                     | `darwin/universal`   | Platform to build for                              |
+| `build-tags`                         | ''                   | Build tags to pass to Go compiler. Must be quoted. |
 | `wails-version`                      | `latest`             | Wails version to use                               |
 | `wails-build-webview2`               | `download`           | Webview2 installing [download,embed,browser,error] |
 | `go-version`                         | `1.18`               | Version of Go to use                               |
 | `node-version`                       | `16.x`               | Node js version                                    |
-| `deno-build`                         | ``                   | Deno compile command                               |
+| `deno-build`                         | ''                   | Deno compile command                               |
 | `deno-working-directory`             | `.`                  | Working directory of your [Deno](https://deno.land/) server|
 | `deno-version`                       | `v1.20.x`            | Deno version to use                                |
 | `sign-macos-app-id`                  | ''                   | ID of the app signing cert                         |

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: "Platform to build for"
     required: false
     default: "darwin/universal"
+  build-tags:
+    description: "Build tags to pass to Go compiler. Must be quoted. Space or comma (but not both) separated"
+    required: false
+    default: ""
   wails-version:
     description: "Wails version to use"
     required: false
@@ -140,22 +144,22 @@ runs:
     - name: Build App
       if: inputs.build == 'true' && runner.os == 'macOS'
       working-directory: ${{ inputs.app-working-directory }}
-      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}}
+      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} -tags '${{inputs.build-tags}}'
       shell: bash
     - name: Build App
       if: inputs.build == 'true' &&  runner.os == 'Linux'
       working-directory: ${{ inputs.app-working-directory }}
-      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}}
+      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} -tags '${{inputs.build-tags}}'
       shell: bash
     - name: Build Windows App
       if: inputs.build == 'true' && runner.os == 'Windows' && inputs.nsis == 'false'
       working-directory: ${{ inputs.app-working-directory }}
-      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}}
+      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} -tags '${{inputs.build-tags}}'
       shell: bash
     - name: Build Windows App + Installer
       if: inputs.build == 'true' && runner.os == 'Windows' && inputs.nsis == 'true'
       working-directory: ${{ inputs.app-working-directory }}
-      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -nsis -o ${{inputs.build-name}}
+      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -nsis -o ${{inputs.build-name}} -tags '${{inputs.build-tags}}'
       shell: bash
     - name: Add macOS perms
       if: inputs.build == 'true' && runner.os == 'macOS'
@@ -217,7 +221,7 @@ runs:
       env:
         APPLE_PASSWORD: ${{ inputs.sign-macos-apple-password }}
       run: |
-        gon -log-level=info ${{ inputs.app-working-directory }}/build/darwin/gon-notarize.json      
+        gon -log-level=info ${{ inputs.app-working-directory }}/build/darwin/gon-notarize.json
     # Windows signing
     - name: Sign Windows binaries
       shell: powershell


### PR DESCRIPTION
When using Ubuntu 24.04, we must pass a tag to the build command in order to use the correct webkit version.

In order to do this, this PR adds a new `build-tags` options which is empty by default.