### PR TITLE
Update upload-artifact action to v4 due to deprecation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -233,7 +233,7 @@ runs:
         echo "Signing Installer" & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe' sign /fd sha256 /tr http://ts.ssl.com /f certificate\certificate.pfx /p '${{ inputs.sign-windows-cert-password }}' .\build\bin\${{inputs.build-name}}-amd64-installer.exe
 
     # Upload build assets
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: inputs.package == 'true'
       with:
         name: Wails Build ${{runner.os}} ${{inputs.build-name}}


### PR DESCRIPTION
V3 of the upload-artifact action is going to be deprecated on January 30th 2025, meaning this action will stop working if `package` is true according to [this article](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). Based on the [migration docs](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md), for this use case, it should be as simple as switching the name from `v3` to `v4`