### PR TITLE
Solving the issue of libwebkit2gtk-4.0-dev problem on Linux build and ditto fault on MacOS build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -225,6 +225,12 @@ runs:
       run: |
         echo "Signing Package"
         gon -log-level=info ./build/darwin/gon-sign.json
+    - name: Rename MacOS App name
+      if: runner.os == 'macOS'
+      working-directory: ${{ inputs.app-working-directory }}
+      shell: bash
+      run: |
+        mv ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.app/Contents/MacOS/${{inputs.build-name}} ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.app/Contents/MacOS/${{inputs.macos-build-name}}
     - name: Build .app zip file
       if: runner.os == 'macOS'
       working-directory: ${{ inputs.app-working-directory }}

--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
       working-directory: ${{ inputs.app-working-directory }}
       shell: bash
       run: |
-        ditto -c -k ${{ inputs.app-working-directory }}/build/bin/ ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.app.zip
+        ditto -c -k --sequesterRsrc --keepParent ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.app.zip
     - name: Building Installer
       if: runner.os == 'macOS' && inputs.sign != 'false' && inputs.sign-macos-installer-id != '' && startsWith(github.ref, 'refs/tags/')
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
       working-directory: ${{ inputs.app-working-directory }}
       shell: bash
       run: |
-        ditto -c -k ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.app.zip
+        ditto -c -k ${{ inputs.app-working-directory }}/build/bin/ ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.app.zip
     - name: Building Installer
       if: runner.os == 'macOS' && inputs.sign != 'false' && inputs.sign-macos-installer-id != '' && startsWith(github.ref, 'refs/tags/')
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -102,16 +102,16 @@ inputs:
   no-node: # project needn't nodejs
     description: "Not use node"
     required: false
-    default: 'false'
+    default: "false"
   no-deno:    
     description: "Not use deno"
     required: false
-    default: 'false'
+    default: "false"
   no-bun:    
     description: "Not use bun"
     required: false
-    default: 'true'
-  nbuntu24:
+    default: "ture"
+  ubuntu24:
     description: "solve libwebkit2gtk-4.0-dev problem"
     required: false
     default: '' # -tags webkit2_41

--- a/action.yml
+++ b/action.yml
@@ -130,7 +130,7 @@ runs:
       shell: bash
     - name: Install Linux Wails deps
       if: inputs.build == 'true' && runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install libgtk-3-0 libwebkit2gtk-4.0-dev gcc-aarch64-linux-gnu
+      run: sudo apt-get update && sudo apt-get install libgtk-3-0 libwebkit2gtk-4.1-dev gcc-aarch64-linux-gnu
       shell: bash
     - name: Install macOS Wails deps
       if: runner.os == 'macOS'
@@ -145,7 +145,7 @@ runs:
     - name: Build App
       if: inputs.build == 'true' &&  runner.os == 'Linux'
       working-directory: ${{ inputs.app-working-directory }}
-      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}}
+      run: wails build -tags webkit2_41 --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}}
       shell: bash
     - name: Build Windows App
       if: inputs.build == 'true' && runner.os == 'Windows' && inputs.nsis == 'false'

--- a/action.yml
+++ b/action.yml
@@ -178,7 +178,7 @@ runs:
     - name: Build App
       if: inputs.build == 'true' &&  runner.os == 'Linux'
       working-directory: ${{ inputs.app-working-directory }}
-      run: wails build $${{inputs.ubuntu24}} --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}}
+      run: wails build ${{inputs.ubuntu24}} --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}}
       shell: bash
     - name: Build Windows App
       if: inputs.build == 'true' && runner.os == 'Windows' && inputs.nsis == 'false'

--- a/action.yml
+++ b/action.yml
@@ -197,7 +197,8 @@ runs:
       working-directory: ${{ inputs.app-working-directory }}
       shell: bash
       run: |
-        ditto -c -k ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app.zip
+        zip -r ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app.zip ${{ inputs.app-working-directory }}/build/bin/*
+        #ditto -c -k ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app.zip
     - name: Building Installer
       if: runner.os == 'macOS' && inputs.sign != 'false' && inputs.sign-macos-installer-id != '' && startsWith(github.ref, 'refs/tags/')
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -215,7 +215,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.app-working-directory }}
       run: |
-        productbuild --component ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.pkg
+        productbuild --component ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.pkg
     - name: Notarising Installer and zip
       if: runner.os == 'macOS' && inputs.sign != 'false' && startsWith(github.ref, 'refs/tags/')
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -129,28 +129,27 @@ runs:
       shell: bash
     # Setup and configure NodeJS
     - name: Setup NodeJS
-      if: no-node == "false"
+      if: inputs.no-node == "false"
       uses: actions/setup-node@v3
       with:
         node-version: ${{inputs.node-version}}
     # (Optional) Setup and configure Deno
     - name: Setup Deno
-      if: no-deno == "false"
+      if: inputs.no-deno == "false" && inputs.deno-build != ''
       uses: denoland/setup-deno@v1
-      if: inputs.deno-build != ''
       with:
         deno-version: ${{inputs.deno-version}}
     - name: Run Deno Command
-      if: no-deno == "false" && inputs.deno-build != ''
+      if: inputs.no-deno == "false" && inputs.deno-build != ''
       shell: bash
       working-directory: ${{inputs.deno-working-directory}}
       run: ${{inputs.deno-build}}
     # Setup Bun
     - name: Setup Bun
-        if: no-bun == "false"
-        uses: oven-sh/setup-bun@v1 # Use the official setup-bun action
-        with:
-          bun-version: latest # Or a specific version like '1.0.0'
+      if: no-bun == "false"
+      uses: oven-sh/setup-bun@v1 # Use the official setup-bun action 
+      with:
+        bun-version: latest # Or a specific version like '1.0.0'
     # install wails
     - name: Install Wails
       if: inputs.build == 'true'

--- a/action.yml
+++ b/action.yml
@@ -95,6 +95,10 @@ inputs:
     description: "Windows Signing Certificate Password"
     required: false
     default: ''
+  macos-build-name:
+    description: "Wails build your App name on Mac"
+    required: false
+    default: 'App'
 
 runs:
   using: "composite"
@@ -108,21 +112,21 @@ runs:
     - run: go version
       shell: bash
     # Setup and configure NodeJS
-    - name: Setup NodeJS
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{inputs.node-version}}
+    # - name: Setup NodeJS
+    #   uses: actions/setup-node@v3
+    #   with:
+    #     node-version: ${{inputs.node-version}}
     # (Optional) Setup and configure Deno
-    - name: Setup Deno
-      uses: denoland/setup-deno@v1
-      if: inputs.deno-build != ''
-      with:
-        deno-version: ${{inputs.deno-version}}
-    - name: Run Deno Command
-      if: inputs.deno-build != ''
-      shell: bash
-      working-directory: ${{inputs.deno-working-directory}}
-      run: ${{inputs.deno-build}}
+    # - name: Setup Deno
+    #   uses: denoland/setup-deno@v1
+    #   if: inputs.deno-build != ''
+    #   with:
+    #     deno-version: ${{inputs.deno-version}}
+    # - name: Run Deno Command
+    #   if: inputs.deno-build != ''
+    #   shell: bash
+    #   working-directory: ${{inputs.deno-working-directory}}
+    #   run: ${{inputs.deno-build}}
     # install wails
     - name: Install Wails
       if: inputs.build == 'true'
@@ -140,6 +144,7 @@ runs:
     - name: Build App
       if: inputs.build == 'true' && runner.os == 'macOS'
       working-directory: ${{ inputs.app-working-directory }}
+      # -o useless till wails 2.9.2
       run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}}
       shell: bash
     - name: Build App
@@ -197,14 +202,14 @@ runs:
       working-directory: ${{ inputs.app-working-directory }}
       shell: bash
       run: |
-        zip -r ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app.zip ${{ inputs.app-working-directory }}/build/bin/*
-        #ditto -c -k ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app.zip
+        #zip -r ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app.zip ${{ inputs.app-working-directory }}/build/bin/*
+        ditto -c -k ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.app.zip
     - name: Building Installer
       if: runner.os == 'macOS' && inputs.sign != 'false' && inputs.sign-macos-installer-id != '' && startsWith(github.ref, 'refs/tags/')
       shell: bash
       working-directory: ${{ inputs.app-working-directory }}
       run: |
-        productbuild --sign '${{inputs.sign-macos-installer-id}}' --component ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.pkg
+        productbuild --sign '${{inputs.sign-macos-installer-id}}' --component ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.pkg
     - name: Building Installer
       if: runner.os == 'macOS' && inputs.sign-macos-installer-id == '' && startsWith(github.ref, 'refs/tags/')
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -95,10 +95,26 @@ inputs:
     description: "Windows Signing Certificate Password"
     required: false
     default: ''
-  macos-build-name:
+  macos-build-name: # fix macos wails build not use -o option #11
     description: "Wails build your App name on Mac"
     required: false
     default: 'App'
+  no-node: # project needn't nodejs
+    description: "Not use node"
+    required: false
+    default: "false"
+  no-deno:    
+    description: "Not use deno"
+    required: false
+    default: "false"
+  no-bun:    
+    description: "Not use bun"
+    required: false
+    default: "true"
+  nbuntu24:
+    description: "solve libwebkit2gtk-4.0-dev problem"
+    required: false
+    default: "" # -tags webkit2_41
 
 runs:
   using: "composite"
@@ -112,28 +128,41 @@ runs:
     - run: go version
       shell: bash
     # Setup and configure NodeJS
-    # - name: Setup NodeJS
-    #   uses: actions/setup-node@v3
-    #   with:
-    #     node-version: ${{inputs.node-version}}
+    - name: Setup NodeJS
+      if: no-node == "false"
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{inputs.node-version}}
     # (Optional) Setup and configure Deno
-    # - name: Setup Deno
-    #   uses: denoland/setup-deno@v1
-    #   if: inputs.deno-build != ''
-    #   with:
-    #     deno-version: ${{inputs.deno-version}}
-    # - name: Run Deno Command
-    #   if: inputs.deno-build != ''
-    #   shell: bash
-    #   working-directory: ${{inputs.deno-working-directory}}
-    #   run: ${{inputs.deno-build}}
+    - name: Setup Deno
+      if: no-deno == "false"
+      uses: denoland/setup-deno@v1
+      if: inputs.deno-build != ''
+      with:
+        deno-version: ${{inputs.deno-version}}
+    - name: Run Deno Command
+      if: no-deno == "false" && inputs.deno-build != ''
+      shell: bash
+      working-directory: ${{inputs.deno-working-directory}}
+      run: ${{inputs.deno-build}}
+    # Setup Bun
+    - name: Setup Bun
+        if: no-bun == "false"
+        uses: oven-sh/setup-bun@v1 # Use the official setup-bun action
+        with:
+          bun-version: latest # Or a specific version like '1.0.0'
     # install wails
     - name: Install Wails
       if: inputs.build == 'true'
       run: go install github.com/wailsapp/wails/v2/cmd/wails@${{inputs.wails-version}}
       shell: bash
     - name: Install Linux Wails deps
-      if: inputs.build == 'true' && runner.os == 'Linux'
+      if: inputs.build == 'true' && runner.os == 'Linux' && ubuntu24 == ""
+      run: sudo apt-get update && sudo apt-get install libgtk-3-0 libwebkit2gtk-4.0-dev gcc-aarch64-linux-gnu
+      shell: bash
+    # build on ubuntu 24
+    - name: Install Linux 24 Wails deps
+      if: inputs.build == 'true' && runner.os == 'Linux' && ubuntu24 != ""
       run: sudo apt-get update && sudo apt-get install libgtk-3-0 libwebkit2gtk-4.1-dev gcc-aarch64-linux-gnu
       shell: bash
     - name: Install macOS Wails deps
@@ -150,7 +179,7 @@ runs:
     - name: Build App
       if: inputs.build == 'true' &&  runner.os == 'Linux'
       working-directory: ${{ inputs.app-working-directory }}
-      run: wails build -tags webkit2_41 --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}}
+      run: wails build $${{inputs.ubuntu24}} --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}}
       shell: bash
     - name: Build Windows App
       if: inputs.build == 'true' && runner.os == 'Windows' && inputs.nsis == 'false'
@@ -202,7 +231,6 @@ runs:
       working-directory: ${{ inputs.app-working-directory }}
       shell: bash
       run: |
-        #zip -r ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app.zip ${{ inputs.app-working-directory }}/build/bin/*
         ditto -c -k ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.macos-build-name}}.app.zip
     - name: Building Installer
       if: runner.os == 'macOS' && inputs.sign != 'false' && inputs.sign-macos-installer-id != '' && startsWith(github.ref, 'refs/tags/')

--- a/action.yml
+++ b/action.yml
@@ -102,19 +102,19 @@ inputs:
   no-node: # project needn't nodejs
     description: "Not use node"
     required: false
-    default: "false"
+    default: 'false'
   no-deno:    
     description: "Not use deno"
     required: false
-    default: "false"
+    default: 'false'
   no-bun:    
     description: "Not use bun"
     required: false
-    default: "true"
+    default: 'true'
   nbuntu24:
     description: "solve libwebkit2gtk-4.0-dev problem"
     required: false
-    default: "" # -tags webkit2_41
+    default: '' # -tags webkit2_41
 
 runs:
   using: "composite"
@@ -129,24 +129,24 @@ runs:
       shell: bash
     # Setup and configure NodeJS
     - name: Setup NodeJS
-      if: inputs.no-node == "false"
+      if: inputs.no-node == 'false'
       uses: actions/setup-node@v3
       with:
         node-version: ${{inputs.node-version}}
     # (Optional) Setup and configure Deno
     - name: Setup Deno
-      if: inputs.no-deno == "false" && inputs.deno-build != ''
+      if: inputs.no-deno == 'false' && inputs.deno-build != ''
       uses: denoland/setup-deno@v1
       with:
         deno-version: ${{inputs.deno-version}}
     - name: Run Deno Command
-      if: inputs.no-deno == "false" && inputs.deno-build != ''
+      if: inputs.no-deno == 'false' && inputs.deno-build != ''
       shell: bash
       working-directory: ${{inputs.deno-working-directory}}
       run: ${{inputs.deno-build}}
     # Setup Bun
     - name: Setup Bun
-      if: no-bun == "false"
+      if: inputs.no-bun == 'false'
       uses: oven-sh/setup-bun@v1 # Use the official setup-bun action 
       with:
         bun-version: latest # Or a specific version like '1.0.0'
@@ -156,12 +156,12 @@ runs:
       run: go install github.com/wailsapp/wails/v2/cmd/wails@${{inputs.wails-version}}
       shell: bash
     - name: Install Linux Wails deps
-      if: inputs.build == 'true' && runner.os == 'Linux' && ubuntu24 == ""
+      if: inputs.build == 'true' && runner.os == 'Linux' && inputs.ubuntu24 == ''
       run: sudo apt-get update && sudo apt-get install libgtk-3-0 libwebkit2gtk-4.0-dev gcc-aarch64-linux-gnu
       shell: bash
     # build on ubuntu 24
     - name: Install Linux 24 Wails deps
-      if: inputs.build == 'true' && runner.os == 'Linux' && ubuntu24 != ""
+      if: inputs.build == 'true' && runner.os == 'Linux' && inputs.ubuntu24 != ''
       run: sudo apt-get update && sudo apt-get install libgtk-3-0 libwebkit2gtk-4.1-dev gcc-aarch64-linux-gnu
       shell: bash
     - name: Install macOS Wails deps


### PR DESCRIPTION
Solving
```
E: Unable to locate package libwebkit2gtk-4.0-dev
E: Couldn't find any package by glob 'libwebkit2gtk-4.0-dev'
E: Couldn't find any package by regex 'libwebkit2gtk-4.0-dev'
```

Solving #11 

Add two input in your action like this

 - name: Build wails
        # uses: dAppServer/wails-build-action@v2.2
        uses: stxh/wails-build-action@pr
        id: build
        with:
          build-name: ${{ matrix.build.name }}
          build-platform: ${{ matrix.build.platform }}
          package: true
          go-version: "1.23"
          macos-build-name: "yourAppName"
          ubuntu24: "-tags webkit2_41"
