### PR TITLE
Garble Support

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -58,20 +58,6 @@ jobs:
           wails-build-webview2: "embed"
           build-obfuscate: true
           package: false # Do not try to upload to github
-  ubuntu-obfuscate-supply-seed:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
-        with:
-          build-name: wails
-          build-platform: linux/amd64
-          wails-build-webview2: "embed"
-          build-obfuscate: true
-          build-obfuscate-args: "-literals -tiny -seed=myrandomseed"
-          package: false # Do not try to upload to github
   macos15arm64:
     runs-on: macos-15
     steps:
@@ -186,6 +172,18 @@ jobs:
           sign-macos-installer-cert: ${{ secrets.MAC_DEVELOPER_INSTALL_CERT }}
           sign-macos-installer-cert-password: ${{ secrets.MAC_DEVELOPER_INSTALL_PASS }}
           package: false # Do not try to upload to github
+  macos-obfuscate:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dAppServer/wails-build-action@33-add-garble-support
+        with:
+          build-name: wails
+          build-platform: darwin/universal
+          build-obfuscate: true
+          package: false # Do not try to upload to github
 
   windows2025:
     runs-on: windows-2025
@@ -238,4 +236,17 @@ jobs:
           build-platform: windows/amd64
           wails-build-webview2: "embed"
           nsis: "true"
+          package: false # Do not try to upload to github
+  windows-obfuscate:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dAppServer/wails-build-action@33-add-garble-support
+        with:
+          build-name: wails.exe
+          build-platform: windows/amd64
+          wails-build-webview2: "embed"
+          build-obfuscate: true
           package: false # Do not try to upload to github

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -45,6 +45,40 @@ jobs:
           build-platform: linux/amd64
           wails-build-webview2: "embed"
           package: false # Do not try to upload to github
+  ubuntu-obfuscate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dAppServer/wails-build-action@33-add-garble-support
+        with:
+          build-name: wails
+          build-platform: linux/amd64
+          wails-build-webview2: "embed"
+          build-obfuscate: true
+          package: false # Do not try to upload to github
+  ubuntu-obfuscate-supply-seed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Generate Random Seed
+        id: generate_seed
+        shell: bash
+        run: |
+          # Generate a random seed (works cross-platform)
+          seed=$(LC_ALL=C tr -dc '[:alnum:]' < /dev/urandom | head -c 16) # 16 characters for seed
+          echo "seed=$seed" >> "$GITHUB_OUTPUT"
+      - uses: dAppServer/wails-build-action@33-add-garble-support
+        with:
+          build-name: wails
+          build-platform: linux/amd64
+          wails-build-webview2: "embed"
+          build-obfuscate: true
+          build-obfuscate-args: "-literals -tiny -seed=${{ steps.generate_seed.outputs.seed }}"
+          package: false # Do not try to upload to github
   macos15arm64:
     runs-on: macos-15
     steps:

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -64,28 +64,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Generate Random Seed
-        id: generate_seed
-        shell: bash
-        run: |
-          seed=""
-          for i in {1..16}; do
-            while true; do  # Loop until an alphanumeric character is generated
-              char=$(( (RANDOM % 62) + 48 ))
-              if [[ $char -ge 48 && $char -le 57 ]] || [[ $char -ge 65 && $char -le 90 ]] || [[ $char -ge 97 && $char -le 122 ]]; then
-                break  # Exit the inner loop if it's alphanumeric
-              fi
-            done
-            seed+="$(printf \\\\$(printf '%o' "$char"))"
-          done
-          echo "seed=$seed" >> "$GITHUB_OUTPUT"
       - uses: dAppServer/wails-build-action@33-add-garble-support
         with:
           build-name: wails
           build-platform: linux/amd64
           wails-build-webview2: "embed"
           build-obfuscate: true
-          build-obfuscate-args: "-literals -tiny -seed=${{ steps.generate_seed.outputs.seed }}"
+          build-obfuscate-args: "-literals -tiny -seed=myrandomseed"
           package: false # Do not try to upload to github
   macos15arm64:
     runs-on: macos-15

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@main
+      - uses: dAppServer/wails-build-action@33-add-garble-support
         with:
           build-name: wails
           build-platform: linux/amd64
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@main
+      - uses: dAppServer/wails-build-action@33-add-garble-support
         with:
           build-name: wails
           build-platform: linux/amd64
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@main
+      - uses: dAppServer/wails-build-action@33-add-garble-support
         with:
           build-name: wails
           build-platform: linux/amd64
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@main
+      - uses: dAppServer/wails-build-action@33-add-garble-support
         with:
           build-name: wails
           build-platform: darwin/universal
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@main
+      - uses: dAppServer/wails-build-action@33-add-garble-support
         with:
           build-name: wails
           build-platform: darwin/universal
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@main
+      - uses: dAppServer/wails-build-action@33-add-garble-support
         with:
           build-name: wails
           build-platform: darwin/universal
@@ -167,7 +167,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@main
+      - uses: dAppServer/wails-build-action@33-add-garble-support
         with:
           build-name: wails.exe
           build-platform: windows/amd64
@@ -180,7 +180,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@main
+      - uses: dAppServer/wails-build-action@33-add-garble-support
         with:
           build-name: wails.exe
           build-platform: windows/amd64
@@ -193,7 +193,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@main
+      - uses: dAppServer/wails-build-action@33-add-garble-support
         with:
           build-name: wails.exe
           build-platform: windows/amd64
@@ -206,7 +206,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@main
+      - uses: dAppServer/wails-build-action@33-add-garble-support
         with:
           build-name: wails.exe
           build-platform: windows/amd64

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -9,20 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  ubuntu2404-wtag:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
-        with:
-          build-name: wails
-          build-platform: linux/amd64
-          build-tags: webkit2_41
-          wails-build-webview2: "embed"
-          package: false # Do not try to upload to github
-  ubuntu2404-wotag:
+  ubuntu2404:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -68,8 +68,16 @@ jobs:
         id: generate_seed
         shell: bash
         run: |
-          # Generate a random seed (works cross-platform)
-          seed=$(LC_ALL=C tr -dc '[:alnum:]' < /dev/urandom | head -c 16) # 16 characters for seed
+          seed=""
+          for i in {1..16}; do
+            while true; do  # Loop until an alphanumeric character is generated
+              char=$(( (RANDOM % 62) + 48 ))
+              if [[ $char -ge 48 && $char -le 57 ]] || [[ $char -ge 65 && $char -le 90 ]] || [[ $char -ge 97 && $char -le 122 ]]; then
+                break  # Exit the inner loop if it's alphanumeric
+              fi
+            done
+            seed+="$(printf \\\\$(printf '%o' "$char"))"
+          done
           echo "seed=$seed" >> "$GITHUB_OUTPUT"
       - uses: dAppServer/wails-build-action@33-add-garble-support
         with:

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  ubuntu2404:
+  ubuntu2404-wtag:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +20,18 @@ jobs:
           build-name: wails
           build-platform: linux/amd64
           build-tags: webkit2_41
+          wails-build-webview2: "embed"
+          package: false # Do not try to upload to github
+  ubuntu2404-wotag:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dAppServer/wails-build-action@33-add-garble-support
+        with:
+          build-name: wails
+          build-platform: linux/amd64
           wails-build-webview2: "embed"
           package: false # Do not try to upload to github
   ubuntu2204:

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "main", "v2", "v3", "dev" ]
+    branches: [ "main", "v2", "v3", "dev", "*-*" ]
   pull_request:
-    branches: [ "main", "v2", "v3", "dev" ]
+    branches: [ "main", "v2", "v3", "dev", "*-*" ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -160,7 +160,6 @@ jobs:
           sign-macos-installer-cert: ${{ secrets.MAC_DEVELOPER_INSTALL_CERT }}
           sign-macos-installer-cert-password: ${{ secrets.MAC_DEVELOPER_INSTALL_PASS }}
           package: false # Do not try to upload to github
-
 
   windows2025:
     runs-on: windows-2025

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
+      - uses: dAppServer/wails-build-action@main
         with:
           build-name: wails
           build-platform: linux/amd64
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
+      - uses: dAppServer/wails-build-action@main
         with:
           build-name: wails
           build-platform: linux/amd64
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
+      - uses: dAppServer/wails-build-action@main
         with:
           build-name: wails
           build-platform: linux/amd64
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
+      - uses: dAppServer/wails-build-action@main
         with:
           build-name: wails
           build-platform: linux/amd64
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
+      - uses: dAppServer/wails-build-action@main
         with:
           build-name: wails
           build-platform: darwin/universal
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
+      - uses: dAppServer/wails-build-action@main
         with:
           build-name: wails
           build-platform: darwin/universal
@@ -159,7 +159,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
+      - uses: dAppServer/wails-build-action@main
         with:
           build-name: wails
           build-platform: darwin/universal
@@ -178,7 +178,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
+      - uses: dAppServer/wails-build-action@main
         with:
           build-name: wails
           build-platform: darwin/universal
@@ -191,7 +191,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
+      - uses: dAppServer/wails-build-action@main
         with:
           build-name: wails.exe
           build-platform: windows/amd64
@@ -204,7 +204,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
+      - uses: dAppServer/wails-build-action@main
         with:
           build-name: wails.exe
           build-platform: windows/amd64
@@ -217,7 +217,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
+      - uses: dAppServer/wails-build-action@main
         with:
           build-name: wails.exe
           build-platform: windows/amd64
@@ -230,7 +230,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
+      - uses: dAppServer/wails-build-action@main
         with:
           build-name: wails.exe
           build-platform: windows/amd64
@@ -243,7 +243,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dAppServer/wails-build-action@33-add-garble-support
+      - uses: dAppServer/wails-build-action@main
         with:
           build-name: wails.exe
           build-platform: windows/amd64

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ By default, the action will build and upload the results to github, on a tagged 
 |--------------------------------------|----------------------|----------------------------------------------------|
 | `build-name`                         | none, required input | The name of the binary                             |
 | `build-obfuscate`                    | `false`              | Obfuscate the binary                               |
-| `build-obfuscate-args`               | `''`                 | Arguments to pass to the obfuscator                |
 | `build`                              | `true`               | Runs `wails build` on your source                  |
 | `nsis`                               | `true`               | Runs `wails build` with or without -nsis           |
 | `sign`                               | `false`              | After build, signs and creates signed installers   |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ By default, the action will build and upload the results to github, on a tagged 
 | Name                                 | Default              | Description                                        |
 |--------------------------------------|----------------------|----------------------------------------------------|
 | `build-name`                         | none, required input | The name of the binary                             |
+| `build-obfuscate`                    | `false`              | Obfuscate the binary                               |
+| `build-obfuscate-args`               | `''`                 | Arguments to pass to the obfuscator                |
 | `build`                              | `true`               | Runs `wails build` on your source                  |
 | `nsis`                               | `true`               | Runs `wails build` with or without -nsis           |
 | `sign`                               | `false`              | After build, signs and creates signed installers   |

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   nsis:
     description: "Build a Windows Installer"
     required: false
-    default: "true"
+    default: "false"
   build-name:
     description: "The name of the binary file"
     required: true
@@ -111,6 +111,47 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Linux Discovery
+      if: runner.os == 'Linux'
+      id: linux_discovery
+      run: |
+        sudo apt-get -yq update
+        DISTRO=$(lsb_release -rs) # Get the distribution version (e.g., "22.04", "24.04")
+        if [[ "$DISTRO" == "20.04" ]]; then
+          sudo apt-get -yq install libgtk-3-0 libwebkit2gtk-4.0-dev gcc-aarch64-linux-gnu
+        elif [[ "$DISTRO" == "22.04" ]]; then
+          sudo apt-get -yq install libgtk-3-0 libwebkit2gtk-4.0-dev gcc-aarch64-linux-gnu
+        elif [[ "$DISTRO" == "24.04" ]]; then
+          sudo apt-get -yq install libgtk-3-0 libwebkit2gtk-4.1-dev gcc-aarch64-linux-gnu
+        else
+          echo "Unsupported Linux distribution: $DISTRO"
+          exit 1 # Fail the workflow if the distribution is not supported
+        fi
+        echo "DISTRO=$DISTRO" >> "$GITHUN_OUPUT"
+      shell: bash
+    - name: Setup Build Options
+      id: build_options
+      shell: bash
+      run: |
+        build_options=""
+        if [[ "${{ inputs.build-obfuscate }}" == 'true' ]]; then
+          build_options+=' -obfuscated'
+        fi
+        if [[ "${{ inputs.build-obfuscate-args }}" != '' ]]; then
+          build_options+=' -garbleargs "${{ inputs.build-obfuscate-args }}"'
+        fi
+        if [[ "${{ inputs.build-tags }}" != "false" ]]; then
+          if [[ "${{ steps.linux_discovery.outputs.DISTRO }}" == '24.04' ]]; then
+            build_options+=' -tags "${{inputs.build-tags}} webkit2_41"'
+          else
+            build_options+=' -tags "${{inputs.build-tags}}"'
+          fi
+        fi
+        echo "SNIDER: ${{ inputs.nsis }}"
+        if [[ ${{ inputs.nsis }} == true ]]; then
+          build_options+=' -nsis'
+        fi
+        echo "BUILD_OPTIONS=$build_options" >> "$GITHUN_OUPUT"
     # Setup and configure GoLang
     - name: Setup GoLang
       uses: actions/setup-go@v4
@@ -163,33 +204,12 @@ runs:
       run: brew install mitchellh/gon/gon
       shell: bash
     # Building step
-    - name: Setup Build Options
-      id: build_options
-      shell: bash
-      run: |
-        build_options=""
-        if [[ "${{ inputs.build-obfuscate }}" == 'true' ]]; then
-          build_options+=' -obfuscated'
-        fi
-        if [[ "${{ inputs.build-obfuscate-args }}" != '' ]]; then
-          build_options+=' -garbleargs "${{ inputs.build-obfuscate-args }}"'
-        fi
-        if [[ "${{ inputs.build-tags }}" != "false" ]]; then
-          if [[ "${{ steps.linux_lsb_release.outputs.DISTRO }}" == '24.04' ]]; then
-            build_options+=' -tags "${{inputs.build-tags}} webkit2_41"'
-          else
-            build_options+=' -tags "${{inputs.build-tags}}"'
-          fi
-        fi
-        echo "SNIDER: ${{ inputs.nsis }}"
-        if [[ ${{ inputs.nsis }} == true ]]; then
-          build_options+=' -nsis'
-        fi
-        echo "::set-output name=build_options::$build_options"
     - name: Build App
       if: inputs.build == 'true'
+      env:
+        BUILD_OPTIONS: ${{ steps.build_options.outputs.BUILD_OPTIONS }}
       working-directory: ${{ inputs.app-working-directory }}
-      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} ${{ steps.build_options.outputs.build_options }}
+      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} $BUILD_OPTIONS
       shell: bash
     - name: Add macOS perms
       if: inputs.build == 'true' && runner.os == 'macOS'

--- a/action.yml
+++ b/action.yml
@@ -141,12 +141,8 @@ runs:
       run: go install github.com/wailsapp/wails/v2/cmd/wails@${{inputs.wails-version}}
       shell: bash
     - name: Install Linux Wails deps
-      if: inputs.build == 'true' && runner.os == 'Linux' && !contains(inputs.build-tags, 'webkit2_41')
-      run: sudo apt-get update && sudo apt-get -yq install libgtk-3-0 libwebkit2gtk-4.0-dev gcc-aarch64-linux-gnu
-      shell: bash
-    - name: Install Linux Wails deps
-      if: inputs.build == 'true' && runner.os == 'Linux' && contains(inputs.build-tags, 'webkit2_41')
-      run: sudo apt-get update && sudo apt-get -yq install libgtk-3-0 libwebkit2gtk-4.1-dev gcc-aarch64-linux-gnu
+      if: inputs.build == 'true' && runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get -yq install libgtk-3-0 libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev gcc-aarch64-linux-gnu
       shell: bash
     - name: Install macOS Wails deps
       if: runner.os == 'macOS'

--- a/action.yml
+++ b/action.yml
@@ -182,7 +182,7 @@ runs:
           fi
         fi
         echo "SNIDER: ${{ inputs.nsis }}"
-        if [[ "${{ inputs.nsis }}" == true ]]; then
+        if [[ ${{ inputs.nsis }} == true ]]; then
           build_options+=' -nsis'
         fi
         echo "::set-output name=build_options::$build_options"

--- a/action.yml
+++ b/action.yml
@@ -140,16 +140,16 @@ runs:
           build_options+=' -obfuscated'
         fi
         if [[ -n "${{ inputs.build-obfuscate-args }}" ]]; then
-          build_options+=' -garbleargs \"${{ inputs.build-obfuscate-args }}\"'
+          build_options+=' -garbleargs "${{ inputs.build-obfuscate-args }}"'
         fi
         if [[ "${{ inputs.build-tags }}" != "false" ]]; then
           tags_string="${{ inputs.build-tags }}"
           if [[ "$DISTRO" == '24.04' ]]; then
             tags_string+=" webkit2_41"
           fi
-          build_options+=" -tags '$tags_string'" 
+          build_options+=" -tags $tags_string" 
         elif [[ "${{ inputs.build-tags }}" == "false" && "$DISTRO" == '24.04' ]]; then 
-          build_options+=" -tags 'webkit2_41'"
+          build_options+=" -tags webkit2_41"
         fi
         if ${{ inputs.nsis == true }}; then
           build_options+=' -nsis'
@@ -198,7 +198,7 @@ runs:
       env:
         BUILD_OPTIONS: ${{ steps.build_options.outputs.BUILD_OPTIONS }}
       working-directory: ${{ inputs.app-working-directory }}
-      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} "$BUILD_OPTIONS"
+      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} $BUILD_OPTIONS
       shell: bash
     - name: Add macOS perms
       if: inputs.build == 'true' && runner.os == 'macOS'

--- a/action.yml
+++ b/action.yml
@@ -154,6 +154,7 @@ runs:
         if ${{ inputs.nsis == true }}; then
           build_options+=' -nsis'
         fi
+        echo "$build_options"
         echo "BUILD_OPTIONS=$build_options" >> "$GITHUB_OUTPUT"
     # Setup and configure GoLang
     - name: Setup GoLang

--- a/action.yml
+++ b/action.yml
@@ -132,6 +132,8 @@ runs:
     - name: Setup Build Options
       id: build_options
       shell: bash
+      env:
+        DISTRO: ${{ steps.linux_discovery.outputs.DISTRO }}
       run: |
         build_options=""
         if [[ "${{ inputs.build-obfuscate }}" == 'true' ]]; then
@@ -141,7 +143,7 @@ runs:
           build_options+=' -garbleargs "${{ inputs.build-obfuscate-args }}"'
         fi
         if [[ "${{ inputs.build-tags }}" != "false" ]]; then
-          if [[ "${{ steps.linux_discovery.outputs.DISTRO }}" == '24.04' ]]; then
+          if [[ "$DISTRO" == '24.04' ]]; then
             build_options+=' -tags "${{inputs.build-tags}} webkit2_41"'
           else
             build_options+=' -tags "${{inputs.build-tags}}"'

--- a/action.yml
+++ b/action.yml
@@ -185,9 +185,6 @@ runs:
         if [[ "${{ inputs.nsis }}" == true ]]; then
           build_options+=' -nsis'
         fi
-        if [[ "${{ steps.linux_lsb_release.outputs.DISTRO }}" == '24.04' ]]; then
-          build_options+=' -nsis'
-        fi
         echo "::set-output name=build_options::$build_options"
     - name: Build App
       if: inputs.build == 'true'

--- a/action.yml
+++ b/action.yml
@@ -147,9 +147,9 @@ runs:
           if [[ "$DISTRO" == '24.04' ]]; then
             tags_string+=" webkit2_41"
           fi
-          build_options+=" -tags '$tags_string'" 
+          build_options+=" -tags $tags_string" 
         elif [[ "${{ inputs.build-tags }}" == "false" && "$DISTRO" == '24.04' ]]; then 
-          build_options+=" -tags 'webkit2_41'"
+          build_options+=" -tags webkit2_41"
         fi
         if ${{ inputs.nsis == true }}; then
           build_options+=' -nsis'

--- a/action.yml
+++ b/action.yml
@@ -127,7 +127,7 @@ runs:
           echo "Unsupported Linux distribution: $DISTRO"
           exit 1 # Fail the workflow if the distribution is not supported
         fi
-        echo "DISTRO=$DISTRO" >> "$GITHUN_OUPUT"
+        echo "DISTRO=$DISTRO" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Setup Build Options
       id: build_options
@@ -151,7 +151,7 @@ runs:
         if [[ ${{ inputs.nsis }} == true ]]; then
           build_options+=' -nsis'
         fi
-        echo "BUILD_OPTIONS=$build_options" >> "$GITHUN_OUPUT"
+        echo "BUILD_OPTIONS=$build_options" >> "$GITHUB_OUTPUT"
     # Setup and configure GoLang
     - name: Setup GoLang
       uses: actions/setup-go@v4

--- a/action.yml
+++ b/action.yml
@@ -181,6 +181,7 @@ runs:
             build_options+=' -tags "${{inputs.build-tags}}"'
           fi
         fi
+        echo "SNIDER: ${{ inputs.nsis }}"
         if [[ "${{ inputs.nsis }}" == 'true' ]]; then
           build_options+=' -nsis'
         fi

--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,7 @@ runs:
           build_options+=' -obfuscated'
         fi
         if [[ -n "${{ inputs.build-obfuscate-args }}" ]]; then
-          build_options+=" -garbleargs '${{ inputs.build-obfuscate-args }}'"
+          build_options+=' -garbleargs \"${{ inputs.build-obfuscate-args }}\"'
         fi
         if [[ "${{ inputs.build-tags }}" != "false" ]]; then
           tags_string="${{ inputs.build-tags }}"
@@ -198,7 +198,7 @@ runs:
       env:
         BUILD_OPTIONS: ${{ steps.build_options.outputs.BUILD_OPTIONS }}
       working-directory: ${{ inputs.app-working-directory }}
-      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} $BUILD_OPTIONS
+      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} "$BUILD_OPTIONS"
       shell: bash
     - name: Add macOS perms
       if: inputs.build == 'true' && runner.os == 'macOS'

--- a/action.yml
+++ b/action.yml
@@ -142,14 +142,18 @@ runs:
         if [[ "${{ inputs.build-obfuscate-args }}" != '' ]]; then
           build_options+=' -garbleargs "${{ inputs.build-obfuscate-args }}"'
         fi
-        if [[ "${{ inputs.build-tags }}" != "false" || "$DISTRO" == '24.04' ]]; then
+        if [[ "${{ inputs.build-tags }}" != "false"]]; then
           if [[ "$DISTRO" == '24.04' ]]; then
             build_options+=" -tags '${{inputs.build-tags}} webkit2_41'"
           else
             build_options+=" -tags '${{inputs.build-tags}}'"
           fi
+        elif [[ "${{ inputs.build-tags }}" == "false" ]]; then
+            if [[ "$DISTRO" == '24.04' ]]; then
+              build_options+=" -tags 'webkit2_41'"
+            fi
+          fi
         fi
-        echo "SNIDER: ${{ inputs.nsis }}"
         if [[ ${{ inputs.nsis }} == true ]]; then
           build_options+=' -nsis'
         fi

--- a/action.yml
+++ b/action.yml
@@ -154,7 +154,6 @@ runs:
         if ${{ inputs.nsis == true }}; then
           build_options+=' -nsis'
         fi
-        echo "$build_options"
         echo "BUILD_OPTIONS=$build_options" >> "$GITHUB_OUTPUT"
     # Setup and configure GoLang
     - name: Setup GoLang

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
   build-tags:
     description: "Build tags to pass to Go compiler. Must be quoted. Space or comma (but not both) separated"
     required: false
-    default: ""
+    default: "false"
   build-obfuscate:
     description: "Obfuscate the build"
     required: false
@@ -142,31 +142,51 @@ runs:
       shell: bash
     - name: Install Linux Wails deps
       if: inputs.build == 'true' && runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get -yq install libgtk-3-0 libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev gcc-aarch64-linux-gnu
+      id: linux_lsb_release
+      run: |
+        DISTRO=$(lsb_release -rs) # Get the distribution version (e.g., "22.04", "24.04")
+        if [[ "$DISTRO" == "20.04" ]]; then
+          sudo apt-get -yq install libgtk-3-0 libwebkit2gtk-4.0-dev gcc-aarch64-linux-gnu
+        elif [[ "$DISTRO" == "22.04" ]]; then
+          sudo apt-get -yq install libgtk-3-0 libwebkit2gtk-4.0-dev gcc-aarch64-linux-gnu
+        elif [[ "$DISTRO" == "24.04" ]]; then
+          sudo apt-get -yq install libgtk-3-0 libwebkit2gtk-4.1-dev gcc-aarch64-linux-gnu
+        else
+          echo "Unsupported Linux distribution: $DISTRO"
+          exit 1 # Fail the workflow if the distribution is not supported
+        fi
+        echo "::set-output name=linux_lsb_release::$DISTRO"
       shell: bash
     - name: Install macOS Wails deps
       if: runner.os == 'macOS'
       run: brew install mitchellh/gon/gon
       shell: bash
     # Building step
-    - name: Set build Options
+    - name: Setup Build Options
       id: build_options
       shell: bash
       run: |
-          build_options="${{ inputs.build-tags }}"
-          if [[ "${{ inputs.build-obfuscate }}" == 'true' ]]; then
-            build_options+=' -obfuscated'
-          fi
-          if [[ "${{ inputs.build-obfuscate-args }}" != '' ]]; then
-            build_options+=' -garbleargs "${{ inputs.build-obfuscate-args }}"'
-          fi
-          if [[ "${{ inputs.build-tags }}" != '' ]]; then
+        build_options=""
+        if [[ "${{ inputs.build-obfuscate }}" == 'true' ]]; then
+          build_options+=' -obfuscated'
+        fi
+        if [[ "${{ inputs.build-obfuscate-args }}" != '' ]]; then
+          build_options+=' -garbleargs "${{ inputs.build-obfuscate-args }}"'
+        fi
+        if [[ "${{ inputs.build-tags }}" != "false" ]]; then
+          if [[ "${{ steps.linux_lsb_release.outputs.DISTRO }}" == '24.04' ]]; then
+            build_options+=' -tags "${{inputs.build-tags}} webkit2_41"'
+          else
             build_options+=' -tags "${{inputs.build-tags}}"'
           fi
-          if [[ "${{ inputs.nsis }}" == 'true' ]]; then
-            build_options+=' -nsis'
-          fi
-          echo "::set-output name=build_options::$build_options"
+        fi
+        if [[ "${{ inputs.nsis }}" == 'true' ]]; then
+          build_options+=' -nsis'
+        fi
+        if [[ "${{ steps.linux_lsb_release.outputs.DISTRO }}" == '24.04' ]]; then
+          build_options+=' -nsis'
+        fi
+        echo "::set-output name=build_options::$build_options"
     - name: Build App
       if: inputs.build == 'true'
       working-directory: ${{ inputs.app-working-directory }}

--- a/action.yml
+++ b/action.yml
@@ -136,25 +136,22 @@ runs:
         DISTRO: ${{ steps.linux_discovery.outputs.DISTRO }}
       run: |
         build_options=""
-        if [[ "${{ inputs.build-obfuscate }}" == 'true' ]]; then
+        if ${{ inputs.build-obfuscate == 'true' }}; then
           build_options+=' -obfuscated'
         fi
-        if [[ "${{ inputs.build-obfuscate-args }}" != '' ]]; then
+        if [[ -n "${{ inputs.build-obfuscate-args }}" ]]; then
           build_options+=' -garbleargs "${{ inputs.build-obfuscate-args }}"'
         fi
-        if [[ "${{ inputs.build-tags }}" != "false"]]; then
+        if [[ "${{ inputs.build-tags }}" != "false" ]]; then
+          tags_string="${{ inputs.build-tags }}"
           if [[ "$DISTRO" == '24.04' ]]; then
-            build_options+=" -tags '${{inputs.build-tags}} webkit2_41'"
-          else
-            build_options+=" -tags '${{inputs.build-tags}}'"
+            tags_string+=" webkit2_41"
           fi
-        elif [[ "${{ inputs.build-tags }}" == "false" ]]; then
-            if [[ "$DISTRO" == '24.04' ]]; then
-              build_options+=" -tags 'webkit2_41'"
-            fi
-          fi
+          build_options+=" -tags '$tags_string'" 
+        elif [[ "${{ inputs.build-tags }}" == "false" && "$DISTRO" == '24.04' ]]; then 
+          build_options+=" -tags 'webkit2_41'"
         fi
-        if [[ ${{ inputs.nsis }} == true ]]; then
+        if ${{ inputs.nsis == true }}; then
           build_options+=' -nsis'
         fi
         echo "BUILD_OPTIONS=$build_options" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -35,10 +35,6 @@ inputs:
     description: "Obfuscate the build"
     required: false
     default: "false"
-  build-obfuscate-args:
-    description: "-garbleargs \"INPUT HERE\""
-    required: false
-    default: ""
   wails-version:
     description: "Wails version to use"
     required: false
@@ -138,9 +134,6 @@ runs:
         build_options=""
         if ${{ inputs.build-obfuscate == 'true' }}; then
           build_options+=' -obfuscated'
-        fi
-        if [[ -n "${{ inputs.build-obfuscate-args }}" ]]; then
-          build_options+=' -garbleargs "${{ inputs.build-obfuscate-args }}"'
         fi
         if [[ "${{ inputs.build-tags }}" != "false" ]]; then
           tags_string="${{ inputs.build-tags }}"

--- a/action.yml
+++ b/action.yml
@@ -144,6 +144,7 @@ runs:
       if: inputs.build == 'true' && runner.os == 'Linux'
       id: linux_lsb_release
       run: |
+        sudo apt-get -yq update
         DISTRO=$(lsb_release -rs) # Get the distribution version (e.g., "22.04", "24.04")
         if [[ "$DISTRO" == "20.04" ]]; then
           sudo apt-get -yq install libgtk-3-0 libwebkit2gtk-4.0-dev gcc-aarch64-linux-gnu

--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,7 @@ runs:
           build_options+=' -obfuscated'
         fi
         if [[ -n "${{ inputs.build-obfuscate-args }}" ]]; then
-          build_options+=" -garbleargs ${{ inputs.build-obfuscate-args }}"
+          build_options+=" -garbleargs '${{ inputs.build-obfuscate-args }}'"
         fi
         if [[ "${{ inputs.build-tags }}" != "false" ]]; then
           tags_string="${{ inputs.build-tags }}"

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,14 @@ inputs:
     description: "Build tags to pass to Go compiler. Must be quoted. Space or comma (but not both) separated"
     required: false
     default: ""
+  build-obfuscate:
+    description: "Obfuscate the build"
+    required: false
+    default: "false"
+  build-obfuscate-args:
+    description: "-garbleargs \"INPUT HERE\""
+    required: false
+    default: ""
   wails-version:
     description: "Wails version to use"
     required: false
@@ -118,7 +126,7 @@ runs:
         node-version: ${{inputs.node-version}}
     # (Optional) Setup and configure Deno
     - name: Setup Deno
-      uses: denoland/setup-deno@v1
+      uses: denoland/setup-deno@v2
       if: inputs.deno-build != ''
       with:
         deno-version: ${{inputs.deno-version}}
@@ -145,25 +153,28 @@ runs:
       run: brew install mitchellh/gon/gon
       shell: bash
     # Building step
+    - name: Set build Options
+      id: build_options
+      shell: bash
+      run: |
+          build_options="${{ inputs.build-tags }}"
+          if [[ "${{ inputs.build-obfuscate }}" == 'true' ]]; then
+            build_options+=' -obfuscated'
+          fi
+          if [[ "${{ inputs.build-obfuscate-args }}" != '' ]]; then
+            build_options+=' -garbleargs "${{ inputs.build-obfuscate-args }}"'
+          fi
+          if [[ "${{ inputs.build-tags }}" != '' ]]; then
+            build_options+=' -tags "${{inputs.build-tags}}"'
+          fi
+          if [[ "${{ inputs.nsis }}" == 'true' ]]; then
+            build_options+=' -nsis'
+          fi
+          echo "::set-output name=build_options::$build_options"
     - name: Build App
-      if: inputs.build == 'true' && runner.os == 'macOS'
+      if: inputs.build == 'true'
       working-directory: ${{ inputs.app-working-directory }}
-      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} -tags '${{inputs.build-tags}}'
-      shell: bash
-    - name: Build App
-      if: inputs.build == 'true' &&  runner.os == 'Linux'
-      working-directory: ${{ inputs.app-working-directory }}
-      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} -tags '${{inputs.build-tags}}'
-      shell: bash
-    - name: Build Windows App
-      if: inputs.build == 'true' && runner.os == 'Windows' && inputs.nsis == 'false'
-      working-directory: ${{ inputs.app-working-directory }}
-      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} -tags '${{inputs.build-tags}}'
-      shell: bash
-    - name: Build Windows App + Installer
-      if: inputs.build == 'true' && runner.os == 'Windows' && inputs.nsis == 'true'
-      working-directory: ${{ inputs.app-working-directory }}
-      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -nsis -o ${{inputs.build-name}} -tags '${{inputs.build-tags}}'
+      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} ${{ steps.build_options.outputs.build_options }}
       shell: bash
     - name: Add macOS perms
       if: inputs.build == 'true' && runner.os == 'macOS'

--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,7 @@ runs:
           build_options+=' -obfuscated'
         fi
         if [[ -n "${{ inputs.build-obfuscate-args }}" ]]; then
-          build_options+=' -garbleargs "${{ inputs.build-obfuscate-args }}"'
+          build_options+=" -garbleargs ${{ inputs.build-obfuscate-args }}"
         fi
         if [[ "${{ inputs.build-tags }}" != "false" ]]; then
           tags_string="${{ inputs.build-tags }}"

--- a/action.yml
+++ b/action.yml
@@ -141,7 +141,7 @@ runs:
           build_options+=' -garbleargs "${{ inputs.build-obfuscate-args }}"'
         fi
         if [[ "${{ inputs.build-tags }}" != "false" ]]; then
-          if [[ ${{!contains(inputs.build-tags, 'webkit2_41')}} && "${{ steps.linux_discovery.outputs.DISTRO }}" == '24.04' ]]; then
+          if [[ "${{ steps.linux_discovery.outputs.DISTRO }}" == '24.04' ]]; then
             build_options+=' -tags "${{inputs.build-tags}} webkit2_41"'
           else
             build_options+=' -tags "${{inputs.build-tags}}"'

--- a/action.yml
+++ b/action.yml
@@ -147,9 +147,9 @@ runs:
           if [[ "$DISTRO" == '24.04' ]]; then
             tags_string+=" webkit2_41"
           fi
-          build_options+=" -tags $tags_string" 
+          build_options+=" -tags '$tags_string'" 
         elif [[ "${{ inputs.build-tags }}" == "false" && "$DISTRO" == '24.04' ]]; then 
-          build_options+=" -tags webkit2_41"
+          build_options+=" -tags 'webkit2_41'"
         fi
         if ${{ inputs.nsis == true }}; then
           build_options+=' -nsis'

--- a/action.yml
+++ b/action.yml
@@ -161,6 +161,10 @@ runs:
       with:
         check-latest: true
         go-version: ${{inputs.go-version}}
+    - name: Install Garble
+      if: inputs.build-obfuscate == 'true'
+      run: go install mvdan.cc/garble@latest
+      shell: bash
     - run: go version
       shell: bash
     # Setup and configure NodeJS

--- a/action.yml
+++ b/action.yml
@@ -182,7 +182,7 @@ runs:
           fi
         fi
         echo "SNIDER: ${{ inputs.nsis }}"
-        if [[ "${{ inputs.nsis }}" == 'true' ]]; then
+        if [[ "${{ inputs.nsis }}" == true ]]; then
           build_options+=' -nsis'
         fi
         if [[ "${{ steps.linux_lsb_release.outputs.DISTRO }}" == '24.04' ]]; then

--- a/action.yml
+++ b/action.yml
@@ -141,7 +141,7 @@ runs:
           build_options+=' -garbleargs "${{ inputs.build-obfuscate-args }}"'
         fi
         if [[ "${{ inputs.build-tags }}" != "false" ]]; then
-          if [[ "${{ steps.linux_discovery.outputs.DISTRO }}" == '24.04' ]]; then
+          if [[ ${{!contains(inputs.build-tags, 'webkit2_41')}} && "${{ steps.linux_discovery.outputs.DISTRO }}" == '24.04' ]]; then
             build_options+=' -tags "${{inputs.build-tags}} webkit2_41"'
           else
             build_options+=' -tags "${{inputs.build-tags}}"'
@@ -180,24 +180,6 @@ runs:
     - name: Install Wails
       if: inputs.build == 'true'
       run: go install github.com/wailsapp/wails/v2/cmd/wails@${{inputs.wails-version}}
-      shell: bash
-    - name: Install Linux Wails deps
-      if: inputs.build == 'true' && runner.os == 'Linux'
-      id: linux_lsb_release
-      run: |
-        sudo apt-get -yq update
-        DISTRO=$(lsb_release -rs) # Get the distribution version (e.g., "22.04", "24.04")
-        if [[ "$DISTRO" == "20.04" ]]; then
-          sudo apt-get -yq install libgtk-3-0 libwebkit2gtk-4.0-dev gcc-aarch64-linux-gnu
-        elif [[ "$DISTRO" == "22.04" ]]; then
-          sudo apt-get -yq install libgtk-3-0 libwebkit2gtk-4.0-dev gcc-aarch64-linux-gnu
-        elif [[ "$DISTRO" == "24.04" ]]; then
-          sudo apt-get -yq install libgtk-3-0 libwebkit2gtk-4.1-dev gcc-aarch64-linux-gnu
-        else
-          echo "Unsupported Linux distribution: $DISTRO"
-          exit 1 # Fail the workflow if the distribution is not supported
-        fi
-        echo "::set-output name=linux_lsb_release::$DISTRO"
       shell: bash
     - name: Install macOS Wails deps
       if: runner.os == 'macOS'

--- a/action.yml
+++ b/action.yml
@@ -142,11 +142,11 @@ runs:
         if [[ "${{ inputs.build-obfuscate-args }}" != '' ]]; then
           build_options+=' -garbleargs "${{ inputs.build-obfuscate-args }}"'
         fi
-        if [[ "${{ inputs.build-tags }}" != "false" ]]; then
+        if [[ "${{ inputs.build-tags }}" != "false" || "$DISTRO" == '24.04' ]]; then
           if [[ "$DISTRO" == '24.04' ]]; then
-            build_options+=' -tags "${{inputs.build-tags}} webkit2_41"'
+            build_options+=" -tags '${{inputs.build-tags}} webkit2_41'"
           else
-            build_options+=' -tags "${{inputs.build-tags}}"'
+            build_options+=" -tags '${{inputs.build-tags}}'"
           fi
         fi
         echo "SNIDER: ${{ inputs.nsis }}"


### PR DESCRIPTION
This pull request includes several updates to the GitHub Actions workflow and action configuration files to support obfuscation and improve build flexibility. The most important changes include adding obfuscation options, updating workflow triggers, and enhancing the setup and build steps.

### Workflow and CI Enhancements:
* [`.github/workflows/build-tests.yml`](diffhunk://#diff-39d761548c91bcae1aff5fcd6a61b89cb28ba44f7f3ac2239343d34c8233561aL5-R7): Updated workflow triggers to include branches matching the pattern `*-*`, added new jobs for obfuscated builds on Ubuntu, macOS, and Windows platforms. [[1]](diffhunk://#diff-39d761548c91bcae1aff5fcd6a61b89cb28ba44f7f3ac2239343d34c8233561aL5-R7) [[2]](diffhunk://#diff-39d761548c91bcae1aff5fcd6a61b89cb28ba44f7f3ac2239343d34c8233561aR48-R60) [[3]](diffhunk://#diff-39d761548c91bcae1aff5fcd6a61b89cb28ba44f7f3ac2239343d34c8233561aL163-R186) [[4]](diffhunk://#diff-39d761548c91bcae1aff5fcd6a61b89cb28ba44f7f3ac2239343d34c8233561aR240-R252)

### Action Configuration Updates:
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L22-R22): Added a new input `build-obfuscate` to enable obfuscation, updated default values for `nsis` and `build-tags`, added steps for Linux distribution discovery and build options setup, and installed Garble for obfuscation. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L22-R22) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L33-R37) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R110-R160) [[4]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L121-R170) [[5]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L135-R194)

### Documentation Update:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31): Documented the new `build-obfuscate` input option.