### PR TITLE
Have macOS installer install to Applications

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -247,13 +247,13 @@ runs:
       shell: bash
       working-directory: ${{ inputs.app-working-directory }}
       run: |
-        productbuild --sign '${{inputs.sign-macos-installer-id}}' --component ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.pkg
+        productbuild --sign '${{inputs.sign-macos-installer-id}}' --component ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app /Applications ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.pkg
     - name: Building Installer
       if: runner.os == 'macOS' && inputs.sign-macos-installer-id == '' && startsWith(github.ref, 'refs/tags/')
       shell: bash
       working-directory: ${{ inputs.app-working-directory }}
       run: |
-        productbuild --component ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.pkg
+        productbuild --component ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app /Applications ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.pkg
     - name: Notarising Installer and zip
       if: runner.os == 'macOS' && inputs.sign != 'false' && startsWith(github.ref, 'refs/tags/')
       shell: bash


### PR DESCRIPTION
I was trying to use the `.pkg` file generated by the macOS runner for this action, and I noticed it didn't seem to install anything. After a lot of trial and error, it turns out the `PackageInfo` file in the `.pkg` (at `<app>.pkg/<app id>/PackageInfo`) has this attribute in the second line:

```
install-location="/Users/runner/work/<name>/<name>/./build/bin"
```
(`<name>` corresponds to my app/repo name, they are the same)

So the installer was working, but just installing the app to a hidden location. 

Looking at the [manpage for productbuild](https://www.manpagez.com/man/1/productbuild/), especially the examples, the solution seems clear.