### PR TITLE
Fixed the comparison of input.nsis

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -148,7 +148,7 @@ runs:
         elif [[ "${{ inputs.build-tags }}" == "false" && "$DISTRO" == '24.04' ]]; then 
           build_options+=" -tags webkit2_41"
         fi
-        if ${{ inputs.nsis == true }}; then
+        if ${{ inputs.nsis == 'true' }}; then
           build_options+=' -nsis'
         fi
         echo "BUILD_OPTIONS=$build_options" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
I failed to create a Windows installer with this Github action. I found a problem in action.yml.

I fixed it because of input.nsis needs to be compared as a string.