### PR TITLE
Expose -debug and -ldflags build options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,10 @@ inputs:
     description: "Obfuscate the build"
     required: false
     default: "false"
+  build-windowsconsole:
+    description: "Keep the console window for Windows builds"
+    required: false
+    default: "false"
   wails-version:
     description: "Wails version to use"
     required: false
@@ -148,6 +152,9 @@ runs:
         fi
         if ${{ inputs.build-obfuscate == 'true' }}; then
           build_options+=' -obfuscated'
+        fi
+        if ${{ inputs.build-windowsconsole == 'true' }}; then
+          build_options+=' -windowsconsole'
         fi
         if [[ "${{ inputs.build-tags }}" != "false" ]]; then
           tags_string="${{ inputs.build-tags }}"

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: "Cache the build"
     required: false
     default: "true"
+  build-debug:
+    description: "Retain debug info and show debug console"
+    required: false
+    default: "false"
   build-platform:
     description: "Platform to build for"
     required: false
@@ -139,6 +143,9 @@ runs:
         DISTRO: ${{ steps.linux_discovery.outputs.DISTRO }}
       run: |
         build_options=""
+        if ${{ inputs.build-debug == 'true' }}; then
+          build_options+=' -debug'
+        fi
         if ${{ inputs.build-obfuscate == 'true' }}; then
           build_options+=' -obfuscated'
         fi

--- a/action.yml
+++ b/action.yml
@@ -176,7 +176,7 @@ runs:
         if ${{ inputs.nsis == 'true' }}; then
           build_options+=' -nsis'
         fi
-        echo "BUILD_OPTIONS=$build_options" >> "$GITHUB_OUTPUT"
+        echo "build_options=$build_options" >> "$GITHUB_OUTPUT"
     # Setup and configure GoLang
     - name: Setup GoLang
       uses: actions/setup-go@v5
@@ -215,10 +215,8 @@ runs:
     # Building step
     - name: Build App
       if: inputs.build == 'true'
-      env:
-        BUILD_OPTIONS: ${{ steps.build_options.outputs.BUILD_OPTIONS }}
       working-directory: ${{ inputs.app-working-directory }}
-      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} $BUILD_OPTIONS
+      run: wails build --platform ${{inputs.build-platform}} -webview2 ${{inputs.wails-build-webview2}} -o ${{inputs.build-name}} ${{ steps.build_options.outputs.build_options }}
       shell: bash
     - name: Add macOS perms
       if: inputs.build == 'true' && runner.os == 'macOS'

--- a/action.yml
+++ b/action.yml
@@ -156,7 +156,7 @@ runs:
         fi
         if [[ "${{ inputs.build-ldflags }}" != "false" ]]; then
           ldflags_string="${{ inputs.build-ldflags }}"
-          build_options+=" -ldflags $ldflags_string"
+          build_options+=" -ldflags=$ldflags_string"
         fi
         if ${{ inputs.build-obfuscate == 'true' }}; then
           build_options+=' -obfuscated'
@@ -169,8 +169,8 @@ runs:
           if [[ "$DISTRO" == '24.04' ]]; then
             tags_string+=" webkit2_41"
           fi
-          build_options+=" -tags $tags_string" 
-        elif [[ "${{ inputs.build-tags }}" == "false" && "$DISTRO" == '24.04' ]]; then 
+          build_options+=" -tags $tags_string"
+        elif [[ "${{ inputs.build-tags }}" == "false" && "$DISTRO" == '24.04' ]]; then
           build_options+=" -tags webkit2_41"
         fi
         if ${{ inputs.nsis == 'true' }}; then

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: false
     default: "false"
   build-ldflags:
-    description: "Additional ldflags to pass to Go compiler. Must be quoted"
+    description: "Additional ldflags to pass to Go compiler."
     required: false
     default: "false"
   build-platform:
@@ -156,7 +156,7 @@ runs:
         fi
         if [[ "${{ inputs.build-ldflags }}" != "false" ]]; then
           ldflags_string="${{ inputs.build-ldflags }}"
-          build_options+=" -ldflags=$ldflags_string"
+          build_options+=" -ldflags='$ldflags_string'"
         fi
         if ${{ inputs.build-obfuscate == 'true' }}; then
           build_options+=' -obfuscated'

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: "Retain debug info and show debug console"
     required: false
     default: "false"
+  build-ldflags:
+    description: "Additional ldflags to pass to Go compiler. Must be quoted"
+    required: false
+    default: "false"
   build-platform:
     description: "Platform to build for"
     required: false
@@ -149,6 +153,10 @@ runs:
         build_options=""
         if ${{ inputs.build-debug == 'true' }}; then
           build_options+=' -debug'
+        fi
+        if [[ "${{ inputs.build-ldflags }}" != "false" ]]; then
+          ldflags_string="${{ inputs.build-ldflags }}"
+          build_options+=" -ldflags $ldflags_string"
         fi
         if ${{ inputs.build-obfuscate == 'true' }}; then
           build_options+=' -obfuscated'


### PR DESCRIPTION
@dexter93 I tired to get [your PR working](https://github.com/dAppServer/wails-build-action/pull/43), but I kept getting errors due to the string passing / quoting issues.

I made a few changes and tested this version which is working. Feel free to incorporate these changes into you PR, or we can just try to get this one merged. Either is ok by me.

I am able to pass ldflags now like this which is a bit nicer UX for multiple flags.

```yaml
    - name: Wails build
      uses: rxfork/wails-build-action@f8b90a113b5f744d191c845a09040632e8821a11
      with:
        build: true
        build-ldflags: >-
          -X=main.AppVersion=${{ steps.meta.outputs.version }}
          -X=main.Foo=${{ inputs.foo }}
```