### PR TITLE
Fixed probable typo in macOS build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -238,7 +238,7 @@ runs:
       working-directory: ${{ inputs.app-working-directory }}
       shell: bash
       run: |
-        ditto -c -k --keepParent ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app.zip
+        ditto -c -k --keepParent build/bin/${{inputs.build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app.zip
     - name: Building Installer
       if: runner.os == 'macOS' && inputs.sign != 'false' && inputs.sign-macos-installer-id != '' && startsWith(github.ref, 'refs/tags/')
       shell: bash


### PR DESCRIPTION
Fixed bug where 'run:' uses working-directory value as prefix to a path argument. This is an issue because it means ditto command attempts to access app-working-directory/app-working-directory, due to 'working-dir:' already being set.