### PR TITLE
Fix build for MacOS and upload artifacts with custom directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -279,11 +279,11 @@ runs:
       with:
         name: Wails Build ${{runner.os}} ${{inputs.build-name}}
         path: |
-          */bin/
-          *\bin\*
+          **/bin/
+          **\bin\*
     - name: Release
       uses: softprops/action-gh-release@v1
       if: inputs.package == 'true' && startsWith(github.ref, 'refs/tags/')
       with:
         files: |
-          */bin/*
+          **/bin/*

--- a/action.yml
+++ b/action.yml
@@ -238,19 +238,19 @@ runs:
       working-directory: ${{ inputs.app-working-directory }}
       shell: bash
       run: |
-        ditto -c -k --keepParent ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app.zip
+        ditto -c -k --keepParent build/bin/${{inputs.build-name}}.app build/bin/${{inputs.build-name}}.app.zip
     - name: Building Installer
       if: runner.os == 'macOS' && inputs.sign != 'false' && inputs.sign-macos-installer-id != '' && startsWith(github.ref, 'refs/tags/')
       shell: bash
       working-directory: ${{ inputs.app-working-directory }}
       run: |
-        productbuild --sign '${{inputs.sign-macos-installer-id}}' --component ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app /Applications ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.pkg
+        productbuild --sign '${{inputs.sign-macos-installer-id}}' --component build/bin/${{inputs.build-name}}.app /Applications build/bin/${{inputs.build-name}}.pkg
     - name: Building Installer
       if: runner.os == 'macOS' && inputs.sign-macos-installer-id == '' && startsWith(github.ref, 'refs/tags/')
       shell: bash
       working-directory: ${{ inputs.app-working-directory }}
       run: |
-        productbuild --component ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.app /Applications ${{ inputs.app-working-directory }}/build/bin/${{inputs.build-name}}.pkg
+        productbuild --component build/bin/${{inputs.build-name}}.app /Applications build/bin/${{inputs.build-name}}.pkg
     - name: Notarising Installer and zip
       if: runner.os == 'macOS' && inputs.sign != 'false' && startsWith(github.ref, 'refs/tags/')
       shell: bash
@@ -258,7 +258,7 @@ runs:
       env:
         APPLE_PASSWORD: ${{ inputs.sign-macos-apple-password }}
       run: |
-        gon -log-level=info ${{ inputs.app-working-directory }}/build/darwin/gon-notarize.json
+        gon -log-level=info build/darwin/gon-notarize.json
     # Windows signing
     - name: Sign Windows binaries
       shell: powershell


### PR DESCRIPTION
This pull request simplifies file path references in the `action.yml` file to improve maintainability and consistency. The changes primarily focus on removing redundant directory prefixes and standardizing path patterns.

### Simplifications in file path references:

* Updated file paths in `runs:` to remove explicit references to `${{ inputs.app-working-directory }}` for macOS build and signing commands, simplifying the paths to relative references like `build/bin/...` and `build/darwin/...`.
* Standardized wildcard patterns in `runs:` by replacing single-level wildcards (`*/bin/` and `*\bin\*`) with multi-level wildcards (`**/bin/` and `**\bin\*`) for better flexibility and accuracy in matching paths.