### PR TITLE
feat(package): publish a .deb alongside the zip

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,20 @@ inputs:
     description: "Base name for release assets, before the -<os>-<arch> suffix"
     required: false
     default: ""
+  deb:
+    description: >
+      Attach a .deb to the release. Linux runners only, and only on a tag.
+      Currently wired for the Go stack; other stacks ignore it.
+    required: false
+    default: "false"
+  deb-maintainer:
+    description: "Debian Maintainer field, as `Name <email>`. Defaults to the repository."
+    required: false
+    default: ""
+  deb-description:
+    description: "One-line package summary. Defaults to the build name."
+    required: false
+    default: ""
   go-directory:
     description: "Where the Go module lives, relative to the working directory"
     required: false
@@ -105,6 +119,9 @@ runs:
         app-working-directory: ${{ inputs.app-working-directory }}
         go-directory: ${{ inputs.go-directory }}
         release-asset-prefix: ${{ inputs.release-asset-prefix }}
+        deb: ${{ inputs.deb }}
+        deb-maintainer: ${{ inputs.deb-maintainer }}
+        deb-description: ${{ inputs.deb-description }}
         main-package: ${{ inputs.main-package }}
         build-tags: ${{ inputs.build-tags }}
         ldflags: ${{ inputs.ldflags }}

--- a/actions/action.yml
+++ b/actions/action.yml
@@ -64,6 +64,18 @@ inputs:
     description: "Base name for release assets, before the -<os>-<arch> suffix"
     required: false
     default: ""
+  deb:
+    description: "Attach a .deb to the release. Linux runners only, Go stack only."
+    required: false
+    default: "false"
+  deb-maintainer:
+    description: "Debian Maintainer field, as `Name <email>`"
+    required: false
+    default: ""
+  deb-description:
+    description: "One-line package summary"
+    required: false
+    default: ""
   go-directory:
     required: false
     default: ""
@@ -164,6 +176,9 @@ runs:
         build-platform: ${{ inputs.build-platform }}
         app-working-directory: ${{ inputs.app-working-directory }}
         release-asset-prefix: ${{ inputs.release-asset-prefix }}
+        deb: ${{ inputs.deb }}
+        deb-maintainer: ${{ inputs.deb-maintainer }}
+        deb-description: ${{ inputs.deb-description }}
         go-directory: ${{ inputs.go-directory }}
         main-package: ${{ inputs.main-package }}
         build-tags: ${{ inputs.build-tags }}

--- a/actions/build/go/action.yml
+++ b/actions/build/go/action.yml
@@ -95,6 +95,18 @@ inputs:
     description: "Base name for release assets, before the -<os>-<arch> suffix"
     required: false
     default: ""
+  deb:
+    description: "Attach a .deb to the release. Linux runners only."
+    required: false
+    default: "false"
+  deb-maintainer:
+    description: "Debian Maintainer field, as `Name <email>`"
+    required: false
+    default: ""
+  deb-description:
+    description: "One-line package summary"
+    required: false
+    default: ""
   app-working-directory:
     description: "Root of the project being built"
     required: false
@@ -178,3 +190,6 @@ runs:
         is-tag: ${{ steps.discovery.outputs.IS_TAG }}
         short-sha: ${{ steps.discovery.outputs.SHORT_SHA }}
         release-asset-prefix: ${{ inputs.release-asset-prefix }}
+        deb: ${{ inputs.deb }}
+        deb-maintainer: ${{ inputs.deb-maintainer }}
+        deb-description: ${{ inputs.deb-description }}

--- a/actions/package/action.yml
+++ b/actions/package/action.yml
@@ -44,6 +44,33 @@ inputs:
     description: "Include artifact_meta.json with discovery metadata in the uploaded artifact"
     required: false
     default: "true"
+  deb:
+    description: >
+      Also build a .deb and attach it to the release. Linux runners only —
+      there is no such thing as a macOS or Windows Debian package, so the step
+      skips elsewhere rather than failing the job.
+    required: false
+    default: "false"
+  deb-maintainer:
+    description: "Debian Maintainer field, as `Name <email>`. Required by policy when deb is on."
+    required: false
+    default: ""
+  deb-description:
+    description: "One-line package summary. Defaults to the repository name."
+    required: false
+    default: ""
+  deb-homepage:
+    description: "Homepage field. Defaults to the repository URL."
+    required: false
+    default: ""
+  deb-depends:
+    description: "Comma-separated Depends. A static Go binary usually needs none."
+    required: false
+    default: ""
+  deb-section:
+    description: "Debian section"
+    required: false
+    default: "devel"
 runs:
   using: "composite"
   steps:
@@ -240,10 +267,108 @@ runs:
 
         test -f "$out"
 
-        rm -rf .release-staging
         echo "[DEBUG_LOG] $staged file(s) into $asset"
         echo "ASSET=$asset" >> "$GITHUB_OUTPUT"
+        echo "OS=$os" >> "$GITHUB_OUTPUT"
+        echo "ARCH=$arch" >> "$GITHUB_OUTPUT"
+        echo "PREFIX=$prefix" >> "$GITHUB_OUTPUT"
         ls -la .release-assets
+
+    - name: Build .deb
+      # Linux only: a Debian package for darwin or windows is meaningless, and
+      # a job that fails for asking is worse than one that says why it skipped.
+      if: inputs.package == 'true' && inputs.deb == 'true' && steps.assets.outputs.ASSET != ''
+      shell: bash
+      env:
+        DEB_OS: ${{ steps.assets.outputs.OS }}
+        DEB_ARCH: ${{ steps.assets.outputs.ARCH }}
+        DEB_NAME: ${{ steps.assets.outputs.PREFIX }}
+        DEB_TAG: ${{ inputs.tag }}
+        DEB_MAINTAINER: ${{ inputs.deb-maintainer }}
+        DEB_DESCRIPTION: ${{ inputs.deb-description }}
+        DEB_HOMEPAGE: ${{ inputs.deb-homepage }}
+        DEB_DEPENDS: ${{ inputs.deb-depends }}
+        DEB_SECTION: ${{ inputs.deb-section }}
+        DEB_REPO: ${{ github.repository }}
+        DEB_SERVER: ${{ github.server_url }}
+      run: |
+        set -euo pipefail
+
+        if [ "$DEB_OS" != "linux" ]; then
+          echo "::notice::no .deb on $DEB_OS — Debian packages are a Linux format"
+          exit 0
+        fi
+        if ! command -v dpkg-deb >/dev/null 2>&1; then
+          echo "::warning::dpkg-deb not available on this runner; skipping the .deb"
+          exit 0
+        fi
+
+        # Debian versions must start with a digit, so the v every Go tag
+        # carries comes off. Without a tag there is no release to attach to.
+        version="${DEB_TAG#v}"
+        if [ -z "$version" ]; then
+          echo "::notice::no tag — nothing to version a .deb with"
+          exit 0
+        fi
+
+        # GOARCH and Debian agree on amd64 and arm64 and disagree on the rest.
+        case "$DEB_ARCH" in
+          amd64)   deb_arch=amd64 ;;
+          arm64)   deb_arch=arm64 ;;
+          386)     deb_arch=i386 ;;
+          arm)     deb_arch=armhf ;;
+          ppc64le) deb_arch=ppc64el ;;
+          *)       deb_arch="$DEB_ARCH" ;;
+        esac
+
+        binary=".release-staging/$DEB_NAME"
+        if [ ! -f "$binary" ]; then
+          binary="$(find .release-staging -maxdepth 1 -type f | head -1)"
+        fi
+        if [ ! -f "$binary" ]; then
+          echo "::warning::no staged binary to package"
+          exit 0
+        fi
+
+        root=".deb-build"
+        rm -rf "$root"
+        mkdir -p "$root/DEBIAN" "$root/usr/bin"
+        install -m 0755 "$binary" "$root/usr/bin/$DEB_NAME"
+
+        maintainer="${DEB_MAINTAINER:-$DEB_REPO <noreply@github.com>}"
+        description="${DEB_DESCRIPTION:-$DEB_NAME}"
+        homepage="${DEB_HOMEPAGE:-$DEB_SERVER/$DEB_REPO}"
+        # In KiB, rounded up: apt shows it before downloading and a 0 reads as
+        # a broken package.
+        size=$(( ( $(wc -c < "$binary") + 1023 ) / 1024 ))
+
+        {
+          echo "Package: $DEB_NAME"
+          echo "Version: $version"
+          echo "Section: ${DEB_SECTION:-devel}"
+          echo "Priority: optional"
+          echo "Architecture: $deb_arch"
+          echo "Maintainer: $maintainer"
+          echo "Installed-Size: $size"
+          [ -n "$DEB_DEPENDS" ] && echo "Depends: $DEB_DEPENDS"
+          echo "Homepage: $homepage"
+          echo "Description: $description"
+        } > "$root/DEBIAN/control"
+
+        deb=".release-assets/${DEB_NAME}_${version}_${deb_arch}.deb"
+        # --root-owner-group so the package does not carry the runner's uid,
+        # which would make the files unownable on the installing machine.
+        dpkg-deb --root-owner-group --build "$root" "$deb"
+
+        test -f "$deb"
+        dpkg-deb --info "$deb"
+        rm -rf "$root"
+        echo "[DEBUG_LOG] built $deb"
+
+    - name: Clean staging
+      if: always()
+      shell: bash
+      run: rm -rf .release-staging
 
     - name: Release
       uses: softprops/action-gh-release@v1

--- a/docs/src/content/docs/reference/packaging.md
+++ b/docs/src/content/docs/reference/packaging.md
@@ -35,6 +35,53 @@ on:
 With that trigger, `main` gives you downloadable artifacts and `v1.2.3` gives
 you a release.
 
+## Release assets
+
+Each platform stages its binary as one zip, `<prefix>-<os>-<arch>.zip`, holding
+the binary under its own name. Two things follow from that shape.
+
+The name carries no version, so `/releases/latest/download/core-linux-amd64.zip`
+resolves — which is what makes a release usable as a download source rather than
+only as a record. And the archive extracts to `core`, not `core-linux-amd64`,
+because the second is a name nobody wants to type or put on `PATH`.
+
+`zip` does the work on Linux and macOS and keeps the executable bit. Windows has
+no `zip`, so PowerShell's `Compress-Archive` covers it — it ships with the OS.
+7-Zip is deliberately not used: it happens to be on GitHub's images, which is
+exactly what makes assuming it a trap on any other runner.
+
+## Debian packages
+
+```yaml
+- uses: dAppCore/build@v4
+  with:
+    build-name: core
+    deb: true
+    deb-maintainer: "Lethean <dev@lethean.io>"
+    deb-description: "Core developer CLI"
+```
+
+A zip is a download; a `.deb` is an install:
+
+```bash
+sudo apt install ./core_1.2.3_amd64.deb
+core --version
+sudo apt remove core
+```
+
+The package goes on PATH, is recorded in the package database, and comes off
+cleanly — none of which unzipping does.
+
+Linux runners only, and only on a tag. A macOS or Windows Debian package is not
+a thing, so the step says so and skips rather than failing the job for asking.
+
+`dpkg-deb` builds it, since it is already on every Ubuntu runner. Architecture is
+translated from GOARCH, because the two vocabularies agree on `amd64` and
+`arm64` and disagree on the rest — `386` has to ship as `i386` or apt will not
+install it on the machine it was built for.
+
+Currently wired for the Go stack. Other stacks accept the input and ignore it.
+
 ## Turning it off
 
 ```yaml


### PR DESCRIPTION
A zip is a download; a `.deb` is an install. `apt install ./core.deb` puts the binary on PATH, records it in the package database, and removes it cleanly — none of which unzipping does.

```yaml
- uses: dAppCore/build@v4
  with:
    build-name: core
    deb: true
    deb-maintainer: "Lethean <dev@lethean.io>"
    deb-description: "Core developer CLI"
```

## Behaviour

Opt-in, Linux runners only, tag only. There is no such thing as a macOS or Windows Debian package, so the step emits a notice and skips rather than failing a job for asking.

`dpkg-deb` builds it — it is on every ubuntu runner, it is the canonical tool, and reaching for the built-in before writing our own is the cheaper correct answer. `--root-owner-group`, so the package does not carry the runner's uid and make its files unownable on the installing machine.

Architecture is translated from GOARCH: the two vocabularies agree on amd64 and arm64 and disagree on the rest, and `386` shipped as an `i386` package is the difference between installable and not.

## One ordering fix

The staging directory was removed at the end of the stage script. The `.deb` step needs the binary that was staged, so cleanup moved to its own `always()` step and staging now also reports `OS`, `ARCH` and `PREFIX`.

## Verification

All 34 action manifests pass `tests/action_contracts.py`.

The package format itself was validated against real `dpkg` on Ubuntu 24.04 via the sibling implementation in [go-build#11](https://github.com/dAppCore/go-build/pull/11) — `dpkg-deb --info`, `apt-get install`, run from `/usr/bin`, `dpkg -V`, clean removal.

Plumbed root → orchestrator → go wrapper → package. Other stacks accept the input at the root and ignore it; that is stated in the input description rather than left to be discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Virgil <virgil@lethean.io>