### PR TITLE
feat(setup): install the core CLI onto the runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,53 @@ jobs:
           if command -v wails >/dev/null 2>&1; then wails version || true; else echo "wails not on PATH (may be Windows PATH nuance), continuing"; fi
  
 
+  setup-core-tests:
+    name: Setup core sub-action on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install core
+        id: core
+        uses: ./actions/setup/core
+        with:
+          token: ${{ github.token }}
+      - name: Assert core is usable, not merely present
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # On PATH by name: a binary installed somewhere the later steps
+          # cannot reach is the failure this job exists to catch.
+          command -v core
+          core --help > /dev/null
+
+          # The surfaces are the reason to install it. core composes
+          # dappco.re/go/build and dappco.re/go/lint, so their absence means
+          # the binary is there but the tooling is not.
+          core --help 2>/dev/null | sed -E 's/\x1b\[[0-9;]*m//g' > surfaces.txt
+          for surface in "build" "go qa" "qa audit"; do
+            grep -qE "^  ${surface}( |\$)" surfaces.txt \
+              || { echo "::error::'$surface' missing from the installed core"; exit 1; }
+          done
+
+          echo "[DEBUG_LOG] core ${{ steps.core.outputs.CORE_VERSION }} via ${{ steps.core.outputs.CORE_METHOD }}"
+
+      - name: Linux takes the native package
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # apt is published for Linux, so falling back to the archive there
+          # means the .deb stopped being attached to releases — worth failing
+          # over, because the fallback would otherwise hide it.
+          test "${{ steps.core.outputs.CORE_METHOD }}" = "apt" \
+            || { echo "::error::Linux installed via '${{ steps.core.outputs.CORE_METHOD }}', expected apt"; exit 1; }
+          dpkg -s core > /dev/null
+
   setup-npm-tests:
     name: Setup npm sub-action on ${{ matrix.os }}
     needs: [options-tests, wails-env-mapping, wails-env-mapping-wrapper]

--- a/actions/setup/core/action.yml
+++ b/actions/setup/core/action.yml
@@ -1,0 +1,170 @@
+name: "Setup core"
+description: >
+  Installs the core CLI onto the runner and puts it on PATH, so every job this
+  action drives has the same build, lint and QA tooling available by name.
+
+  The point is a known environment. core composes dappco.re/go/build and
+  dappco.re/go/lint, so a runner with core on it can build and check any CoreGO
+  project without installing anything further — and an agent sandbox given the
+  same install has the same surface, tested by the same path CI uses.
+
+  Native packaging is preferred where it exists, because a package manager
+  records what it installed and can remove it: apt on Linux today. macOS and
+  Windows fall back to the release archive until a current tap and a Windows
+  manifest are published. The fallback is not a lesser path — it is what the
+  generated installers use, so it gets exercised constantly.
+
+inputs:
+  version:
+    description: "Release tag to install, or `latest`"
+    required: false
+    default: "latest"
+  repository:
+    description: "Repository publishing the core releases"
+    required: false
+    default: "dAppCore/cli"
+  method:
+    description: >
+      `auto` prefers a native package and falls back to the archive.
+      `archive` always takes the zip. `package` fails if no native package
+      applies, rather than quietly installing another way.
+    required: false
+    default: "auto"
+  token:
+    description: "Token for the releases API, to avoid anonymous rate limits"
+    required: false
+    default: ""
+
+outputs:
+  CORE_VERSION:
+    description: "The version that ended up on PATH"
+    value: ${{ steps.install.outputs.CORE_VERSION }}
+  CORE_METHOD:
+    description: "How it was installed: apt or archive"
+    value: ${{ steps.install.outputs.CORE_METHOD }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install core
+      id: install
+      shell: bash
+      env:
+        IN_VERSION: ${{ inputs.version }}
+        IN_REPO: ${{ inputs.repository }}
+        IN_METHOD: ${{ inputs.method }}
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+
+        case "$(uname -s)" in
+          Linux*)   os=linux ;;
+          Darwin*)  os=darwin ;;
+          MINGW*|MSYS*|CYGWIN*) os=windows ;;
+          *) echo "::error::unsupported OS: $(uname -s)"; exit 1 ;;
+        esac
+        case "$(uname -m)" in
+          x86_64|amd64)   arch=amd64 ;;
+          aarch64|arm64)  arch=arm64 ;;
+          *) echo "::error::unsupported architecture: $(uname -m)"; exit 1 ;;
+        esac
+
+        # The tag is needed by name even for `latest`: release assets are named
+        # without a version so /releases/latest/download resolves, but the .deb
+        # carries its version in the filename, and reporting what was installed
+        # requires knowing it either way.
+        version="$IN_VERSION"
+        if [ "$version" = "latest" ]; then
+          api="https://api.github.com/repos/$IN_REPO/releases/latest"
+          if [ -n "${GH_TOKEN:-}" ]; then
+            version="$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" "$api" | grep -m1 '"tag_name"' | cut -d'"' -f4)"
+          else
+            version="$(curl -fsSL "$api" | grep -m1 '"tag_name"' | cut -d'"' -f4)"
+          fi
+        fi
+        if [ -z "$version" ]; then
+          echo "::error::could not resolve a release tag from $IN_REPO"
+          exit 1
+        fi
+
+        base="https://github.com/$IN_REPO/releases/download/$version"
+        method=""
+
+        # ── Native package ───────────────────────────────────────────────────
+        # apt is the one channel published today. dpkg -i would leave a package
+        # unconfigured on a missing dependency; apt resolves instead, and a
+        # local .deb path is a first-class argument to it.
+        if [ "$IN_METHOD" != "archive" ] && [ "$os" = "linux" ] && command -v apt-get >/dev/null 2>&1; then
+          case "$arch" in
+            amd64) deb_arch=amd64 ;;
+            arm64) deb_arch=arm64 ;;
+            *)     deb_arch="" ;;
+          esac
+          if [ -n "$deb_arch" ]; then
+            deb="core_${version#v}_${deb_arch}.deb"
+            if curl -fsSL -o "/tmp/$deb" "$base/$deb" 2>/dev/null; then
+              sudo apt-get install -y "/tmp/$deb"
+              rm -f "/tmp/$deb"
+              method=apt
+            else
+              echo "::notice::no $deb published for $version — falling back to the archive"
+            fi
+          fi
+        fi
+
+        # ── Archive ──────────────────────────────────────────────────────────
+        if [ -z "$method" ]; then
+          if [ "$IN_METHOD" = "package" ]; then
+            echo "::error::no native package for $os/$arch, and method is 'package'"
+            exit 1
+          fi
+
+          archive="core-${os}-${arch}.zip"
+          tmp="$(mktemp -d)"
+          curl -fsSL -o "$tmp/$archive" "$base/$archive"
+
+          # unzip is absent from a Windows runner's Git Bash; PowerShell ships
+          # with the OS and covers it. Both are given a relative path, because
+          # $PWD under Git Bash is /d/a/... and PowerShell reads that as
+          # D:\d\a\..., which does not exist.
+          if command -v unzip >/dev/null 2>&1; then
+            unzip -q -o "$tmp/$archive" -d "$tmp"
+          elif command -v pwsh >/dev/null 2>&1 || command -v powershell >/dev/null 2>&1; then
+            PS_BIN=pwsh
+            command -v pwsh >/dev/null 2>&1 || PS_BIN=powershell
+            ( cd "$tmp" && "$PS_BIN" -NoProfile -Command "Expand-Archive -Path '$archive' -DestinationPath '.' -Force" )
+          else
+            echo "::error::no unzip and no PowerShell available to extract $archive"
+            exit 1
+          fi
+
+          binary="core"
+          [ "$os" = "windows" ] && binary="core.exe"
+          test -f "$tmp/$binary"
+
+          install_dir="$HOME/.local/bin"
+          mkdir -p "$install_dir"
+          # install(1) sets the mode in one step; Windows has no cp -p semantics
+          # worth relying on, so chmod follows the copy there.
+          if [ "$os" = "windows" ]; then
+            cp "$tmp/$binary" "$install_dir/$binary"
+          else
+            install -m 0755 "$tmp/$binary" "$install_dir/$binary"
+          fi
+          echo "$install_dir" >> "$GITHUB_PATH"
+          export PATH="$install_dir:$PATH"
+          rm -rf "$tmp"
+          method=archive
+        fi
+
+        # Asserted, not assumed: an install that put a file somewhere PATH does
+        # not reach is the failure this step exists to prevent.
+        if ! command -v core >/dev/null 2>&1; then
+          echo "::error::core is not on PATH after installing via $method"
+          exit 1
+        fi
+        reported="$(core --help 2>/dev/null | sed -E 's/\x1b\[[0-9;]*m//g' | head -1)"
+
+        echo "[DEBUG_LOG] (core) $reported via $method"
+        echo "CORE_VERSION=$version" >> "$GITHUB_OUTPUT"
+        echo "CORE_METHOD=$method" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
`core` composes `dappco.re/go/build` and `dappco.re/go/lint`, so a runner with `core` on it has the build and QA tooling for every CoreGO project without installing anything further.

The same install path serves an agent sandbox — which is the point. The environment a harness gets is the one CI exercises on every run, not a second recipe that drifts away from it.

```yaml
- uses: dAppCore/build/actions/setup/core@v4
- run: core go qa
```

## Native where it exists, archive where it does not

A package manager records what it installed and can remove it again, so it wins when available:

| runner | today | via |
| :-- | :-- | :-- |
| Linux | `.deb` | `apt-get install ./core_<v>_<arch>.deb` |
| macOS | archive | tap formula is stale at `0.0.4-alpha.21` and points at dead URLs |
| Windows | archive | no winget/scoop/choco manifest published |

The fallback is not a lesser path — it is what the generated installers use, so it is exercised constantly. As a current tap and a Windows manifest get published, those rows change without the action's contract changing.

```
method: auto      native package, else archive   (default)
method: package   fail rather than quietly installing another way
method: archive   always the zip
```

## What the CI job asserts

The surfaces, not the file. A binary that installs but composed nothing is the failure worth catching, so `build`, `go qa` and `qa audit` must appear in the catalog on all three runners.

Linux additionally asserts it came via **apt**. Falling back there would mean the `.deb` had stopped being attached to releases, and the fallback would otherwise hide that.

## Root action wiring is deliberately not here

A composite manifest is validated up front, so a step naming `dAppCore/build/actions/setup/core@v4` fails *every* job using the root action until `v4` actually carries that path — including the six jobs in this repo's own CI that use `uses: ./`.

So: this PR ships the sub-action, then `v4` moves, then a follow-up adds `core: true` to the root action. Same two-step the repo has always needed for a new sub-action.

## Verified

The chain this depends on was tested end to end against the real v0.12.5 release on Ubuntu 24.04:

```
apt install ./core_0.12.5_amd64.deb   →  Setting up core (0.12.5)
core --help                           →  core v0.12.5
core build installers ...             →  ARCHIVE="${BINARY_NAME}-${OS}-${ARCH}.zip"
bash ci.sh                            →  core v0.12.5 ready.
```

That last pair is the loop closing: `core`, installed from a `.deb`, generating an installer that installs `core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Virgil <virgil@lethean.io>