### PR TITLE
feat(deno): pass entry and permissions through the root action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,19 @@ inputs:
     description: "Base name for release assets, before the -<os>-<arch> suffix"
     required: false
     default: ""
+  entry:
+    description: >
+      Deno stack: entry module to compile. Empty probes for run.ts, main.ts,
+      mod.ts, src/main.ts and app.ts in that order.
+    required: false
+    default: ""
+  permissions:
+    description: >
+      Deno stack: permission flags baked into the compiled binary. The default
+      is read-only over the network; a server that writes files or spawns
+      processes needs more.
+    required: false
+    default: ""
   deb:
     description: >
       Attach a .deb to the release. Linux runners only, and only on a tag.
@@ -119,6 +132,8 @@ runs:
         app-working-directory: ${{ inputs.app-working-directory }}
         go-directory: ${{ inputs.go-directory }}
         release-asset-prefix: ${{ inputs.release-asset-prefix }}
+        entry: ${{ inputs.entry }}
+        permissions: ${{ inputs.permissions }}
         deb: ${{ inputs.deb }}
         deb-maintainer: ${{ inputs.deb-maintainer }}
         deb-description: ${{ inputs.deb-description }}

--- a/actions/action.yml
+++ b/actions/action.yml
@@ -64,6 +64,14 @@ inputs:
     description: "Base name for release assets, before the -<os>-<arch> suffix"
     required: false
     default: ""
+  entry:
+    description: "Deno stack: entry module to compile. Empty probes for the usual names."
+    required: false
+    default: ""
+  permissions:
+    description: "Deno stack: permission flags baked into the compiled binary"
+    required: false
+    default: ""
   deb:
     description: "Attach a .deb to the release. Linux runners only, Go stack only."
     required: false
@@ -238,6 +246,8 @@ runs:
         build-name: ${{ inputs.build-name }}
         app-working-directory: ${{ inputs.app-working-directory }}
         release-asset-prefix: ${{ inputs.release-asset-prefix }}
+        entry: ${{ inputs.entry }}
+        permissions: ${{ inputs.permissions }}
 
     # core is a library pipeline, not a builder — vet, test, lint, vulncheck.
     # It produces no artifact, so `build-name` and `package` do not reach it and


### PR DESCRIPTION
The deno stack accepts both, but neither reached it from `dAppCore/build@v4`, so anything needing more than the default `--allow-net --allow-read --allow-env` had to call the stack directly.

**`permissions` is the one that matters.** A compiled server that writes config or spawns a process fails at runtime under the default — and the failure surfaces from *inside* the binary, so it reads as a bug in the server rather than in its build.

`entry` is usually unnecessary, since the build step already probes `run.ts`, `main.ts`, `mod.ts`, `src/main.ts` and `app.ts`. But a project outside that set had no way to say so through the root action.

```yaml
- uses: dAppCore/build@v4
  with:
    build-name: corets
    STACK: deno
    permissions: "-A"
```

Found by pointing the action at [dAppCore/ts](https://github.com/dAppCore/ts) — the Danet server — which needs `-A` because it writes keys and spawns processes.

Plumbed root → orchestrator → deno wrapper. All 35 action manifests pass `tests/action_contracts.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Virgil <virgil@lethean.io>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `entry` configuration to specify the Deno module used during compilation.
  * Added optional `permissions` configuration to define permission flags embedded in compiled binaries.
  * Both settings are forwarded automatically to the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->