### PR TITLE
fix(deno): let the Deno stack produce a .deb

### DIFF
--- a/actions/action.yml
+++ b/actions/action.yml
@@ -255,6 +255,9 @@ runs:
         release-asset-prefix: ${{ inputs.release-asset-prefix }}
         entry: ${{ inputs.entry }}
         permissions: ${{ inputs.permissions }}
+        deb: ${{ inputs.deb }}
+        deb-maintainer: ${{ inputs.deb-maintainer }}
+        deb-description: ${{ inputs.deb-description }}
 
     # core is a library pipeline, not a builder — vet, test, lint, vulncheck.
     # It produces no artifact, so `build-name` and `package` do not reach it and

--- a/actions/build/deno/action.yml
+++ b/actions/build/deno/action.yml
@@ -51,6 +51,18 @@ inputs:
     description: "Base name for release assets, before the -<os>-<arch> suffix"
     required: false
     default: ""
+  deb:
+    description: "Attach a .deb to the release. Linux runners only."
+    required: false
+    default: "false"
+  deb-maintainer:
+    description: "Debian Maintainer field, as `Name <email>`"
+    required: false
+    default: ""
+  deb-description:
+    description: "One-line package summary"
+    required: false
+    default: ""
   app-working-directory:
     description: "Directory holding deno.json"
     required: false
@@ -147,3 +159,6 @@ runs:
         is-tag: ${{ steps.discovery.outputs.IS_TAG }}
         short-sha: ${{ steps.discovery.outputs.SHORT_SHA }}
         release-asset-prefix: ${{ inputs.release-asset-prefix }}
+        deb: ${{ inputs.deb }}
+        deb-maintainer: ${{ inputs.deb-maintainer }}
+        deb-description: ${{ inputs.deb-description }}

--- a/tests/action_contracts.py
+++ b/tests/action_contracts.py
@@ -69,6 +69,8 @@ def callee_path(uses: str) -> pathlib.Path | None:
 
 def main() -> int:
     problems: list[str] = []
+    # callee -> input -> {caller: forwards?}, for the asymmetry report below.
+    wiring: dict[str, dict[str, dict[str, bool]]] = {}
 
     for path in action_files():
         rel = path.relative_to(ROOT)
@@ -129,6 +131,8 @@ def main() -> int:
             forwarded = set((step.get("with") or {}).keys())
             target_rel = str(target.relative_to(ROOT))
             for name in (callee.get("inputs") or {}):
+                wiring.setdefault(target_rel, {}).setdefault(name, {})[str(rel)] = (
+                    name in forwarded)
                 if name in declared and name not in forwarded:
                     if (target_rel, name) in PASSTHROUGH_EXEMPT:
                         continue
@@ -137,12 +141,38 @@ def main() -> int:
                         f"{rel}: '{label}' does not forward {name} to {target_rel} — "
                         f"the callee will use its own default")
 
+    # Opt-in, and never a failure. The check above catches an input a caller
+    # declares and forgets to wire; it cannot catch one a caller never declared
+    # at all, because not declaring it is how a stack says it does not offer
+    # the option — and `deb` reached the Go stack and not the Deno one exactly
+    # that way. Most asymmetries are correct (wails3 does not take wails2's
+    # options), so printing them on every run would only teach people to skip
+    # the output. Reach for `--asymmetries` when wiring a new stack or hunting
+    # an option that appears to do nothing.
+    asymmetries: list[str] = []
+    for callee, inputs in sorted(wiring.items()):
+        for name, callers in sorted(inputs.items()):
+            missing = sorted(c for c, ok in callers.items() if not ok)
+            if missing and len(missing) != len(callers):
+                has = sorted(c for c, ok in callers.items() if ok)
+                asymmetries.append(
+                    f"  {callee} :: {name}\n"
+                    f"      wired by  {', '.join(has)}\n"
+                    f"      not by    {', '.join(missing)}")
+
     if problems:
         print("\n".join(f"  {p}" for p in problems))
         print(f"\n{len(problems)} problem(s)")
         return 1
 
     print(f"checked {len(list(action_files()))} action.yml files — all sound")
+    if "--asymmetries" in sys.argv:
+        print(f"\n{len(asymmetries)} input(s) wired by some callers of a callee "
+              f"and not others:\n")
+        print("\n".join(asymmetries))
+    elif asymmetries:
+        print(f"({len(asymmetries)} caller asymmetries — "
+              f"run with --asymmetries to list them)")
     return 0
 
 


### PR DESCRIPTION
`deb`, `deb-maintainer` and `deb-description` reach the root action and the orchestrator, and the **Go** stack declares them and hands them to `package`. The **Deno** stack never declared them, so the chain dead-ended there.

A Deno caller could set `deb: true`, watch the build go green, and get no `.deb`. dAppCore/ts asked for one:

```yaml
package: true
deb: true
deb-maintainer: "Lethean <dev@lethean.io>"
deb-description: "CoreTS — client-side application server"
```

…and the Linux job produced only the zip. No `dpkg-deb` anywhere in the log.

## Why #79's check missed it

That check looks for an input **both** a caller and its callee declare, where the caller forgets to forward. Not declaring an input is precisely how a stack says *it does not offer that option* — so "never declared" and "deliberately withheld" look identical to it. It was never going to catch this one.

It now also records, per callee input, which callers wire it and which don't:

```
$ python3 tests/action_contracts.py --asymmetries

  actions/package/action.yml :: deb
      wired by  actions/build/deno/action.yml, actions/build/go/action.yml
      not by    actions/build/bun/action.yml, actions/build/cpp/action.yml,
                actions/build/node/action.yml, actions/build/wails2/action.yml,
                actions/build/wails3/action.yml
```

**Opt-in, and never fails.** Most of the 33 it lists are correct — wails3 genuinely doesn't take wails2's options — so surfacing them every run would only teach people to skip the output, the same reasoning already applied to the lint job. It's the tool for wiring a new stack, or for working out why an option appears to do nothing.

The remaining `deb` gaps (bun, cpp, node, wails2, wails3) are a feature question, not a wiring bug, and are left alone.

## Verification

```
$ python3 tests/action_contracts.py
checked 35 action.yml files — all sound
(33 caller asymmetries — run with --asymmetries to list them)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Virgil <virgil@lethean.io>