### PR TITLE
fix(wails3): forward `task`, and report inputs no caller can reach

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,13 @@ inputs:
     description: "Base name for release assets, before the -<os>-<arch> suffix"
     required: false
     default: ""
+  task:
+    description: >
+      Wails v3 stack: the Taskfile target to run. Empty runs <os>:build, which
+      produces a bare binary — a project wanting the bundle or an installer
+      names its package target here.
+    required: false
+    default: ""
   entry:
     description: >
       Deno stack: entry module to compile. Empty probes for run.ts, main.ts,

--- a/actions/action.yml
+++ b/actions/action.yml
@@ -172,6 +172,12 @@ runs:
         build-name: ${{ inputs.build-name }}
         app-working-directory: ${{ inputs.app-working-directory }}
         release-asset-prefix: ${{ inputs.release-asset-prefix }}
+        # The v3 stack runs the project's own Taskfile target, so which target
+        # is the whole configuration. Unforwarded it defaulted to <os>:build on
+        # every caller — a caller asking for a package target got a bare binary
+        # and no error, because Actions ignores a `with:` key the action does
+        # not declare.
+        task: ${{ inputs.task }}
 
     - name: Call Go wrapper
       id: go

--- a/tests/action_contracts.py
+++ b/tests/action_contracts.py
@@ -150,15 +150,28 @@ def main() -> int:
     # the output. Reach for `--asymmetries` when wiring a new stack or hunting
     # an option that appears to do nothing.
     asymmetries: list[str] = []
+    # Inputs no caller wires at all. The asymmetry report cannot show these —
+    # it compares callers against each other, and unanimous silence looks like
+    # agreement — yet they are the worse case: the option exists on the callee,
+    # is documented there, and cannot be reached through the caller at all. A
+    # workflow that sets one gets no error, because Actions ignores an unknown
+    # `with:` key. That is how `task` reached the wails3 stack and never left
+    # the root action, pinning every v3 build to <os>:build.
+    unreachable: list[str] = []
     for callee, inputs in sorted(wiring.items()):
         for name, callers in sorted(inputs.items()):
             missing = sorted(c for c, ok in callers.items() if not ok)
-            if missing and len(missing) != len(callers):
-                has = sorted(c for c, ok in callers.items() if ok)
-                asymmetries.append(
-                    f"  {callee} :: {name}\n"
-                    f"      wired by  {', '.join(has)}\n"
-                    f"      not by    {', '.join(missing)}")
+            if not missing:
+                continue
+            if len(missing) == len(callers):
+                unreachable.append(f"  {callee} :: {name}\n"
+                                   f"      reached by no caller ({', '.join(missing)})")
+                continue
+            has = sorted(c for c, ok in callers.items() if ok)
+            asymmetries.append(
+                f"  {callee} :: {name}\n"
+                f"      wired by  {', '.join(has)}\n"
+                f"      not by    {', '.join(missing)}")
 
     if problems:
         print("\n".join(f"  {p}" for p in problems))
@@ -170,9 +183,12 @@ def main() -> int:
         print(f"\n{len(asymmetries)} input(s) wired by some callers of a callee "
               f"and not others:\n")
         print("\n".join(asymmetries))
-    elif asymmetries:
-        print(f"({len(asymmetries)} caller asymmetries — "
-              f"run with --asymmetries to list them)")
+        print(f"\n{len(unreachable)} input(s) no caller wires — settable on the "
+              f"callee, unreachable through it:\n")
+        print("\n".join(unreachable))
+    elif asymmetries or unreachable:
+        print(f"({len(asymmetries)} caller asymmetries, {len(unreachable)} "
+              f"unreachable inputs — run with --asymmetries to list them)")
     return 0
 
 


### PR DESCRIPTION
The v3 stack runs the project's own Taskfile target rather than composing a command, so *which* target runs is the entire configuration. The root action never declared `task` and the orchestrator never forwarded it — so every v3 build ran `<os>:build` regardless of what the caller asked for, and a caller that asked got no error, because Actions ignores a `with:` key the action does not declare.

`lthn/desktop` asked for `darwin:package`, got `darwin:build`, and its next step failed on a bundle that was never created:

```
task: bin/lthn.app not found. Run `go tool wails3 task darwin:package` ... first.
task: precondition not met
```

macOS and Windows both went red and the release published nothing.

## Why the contract check missed it

`--asymmetries` compares a callee's callers against each other, so an input that *no* caller wires reads as unanimous agreement rather than as a dead option. That is the worse case — the option is declared and documented on the callee, and unreachable through the caller.

Those now get their own section, and the count appears in the default output so a change in the number is visible:

```
checked 35 action.yml files — all sound
(33 caller asymmetries, 79 unreachable inputs — run with --asymmetries to list them)
```

79, down from 80 with this fix. Most of the rest are deliberate — a wrapper choosing not to expose a knob — so this reports rather than fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Virgil <virgil@lethean.io>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `task` input for Wails v3 projects, allowing a specific Taskfile target to be selected.
  * The selected task is now correctly passed through to the Wails v3 workflow.

* **Tests**
  * Improved action contract diagnostics to identify inputs that are not connected to any caller.
  * Summary output now reports both partially connected and unreachable inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->